### PR TITLE
Don't miss char data when restricting a mixed type

### DIFF
--- a/xsd/testdata/mixed.xsd
+++ b/xsd/testdata/mixed.xsd
@@ -1,0 +1,72 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns="http://example.net"
+           targetNamespace="http://example.net">
+  <!-- in the following schema, (almost) all types have a mixed content type. -->
+
+  <!-- explicit mixed=true on complexType -->
+  <xs:complexType name="MIXED_explicit" mixed="true">
+    <xs:element name="value" type="xs:decimal"/>
+  </xs:complexType>
+
+  <!-- explicit mixed=true on complexContent -->
+  <xs:complexType name="MIXED_explicitComplexContent">
+    <xs:complexContent mixed="true">
+      <xs:extension base="xs:anyType">
+        <xs:element name="value" type="xs:decimal"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- implicit mixed by extending anyType -->
+  <xs:complexType name="MIXED_extendAnyType">
+    <xs:complexContent>
+      <xs:extension base="xs:anyType">
+        <xs:element name="value" type="xs:decimal"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- implicit mixed by extending a simple type (this is our
+       own interpretation of the spec) -->
+  <xs:complexType name="MIXED_extendSimpleType">
+    <xs:simpleContent>
+      <xs:extension base="xs:decimal">
+        <xs:attribute name="precision" type="xs:int"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- implicit mixed by restricting a simple type (see above comment) -->
+  <xs:complexType name="MIXED_restrictSimpleType">
+    <xs:simpleContent>
+      <xs:restriction base="xs:decimal">
+        <xs:minInclusive value="100"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <!-- implicit mixed by extending a mixed complexType -->
+  <xs:complexType name="MIXED_extendMixedComplexType">
+    <xs:complexContent>
+      <xs:extension base="MIXED_explicit">
+        <xs:element name="geo" type="xs:string"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- NOT MIXED: restricting a mixed type (explicit) -->
+  <xs:complexType name="NOTMIXED_explicitRestrictMixedType" mixed="false">
+    <xs:complexContent>
+      <xs:restriction base="MIXED_explicit">
+      </xs:restriction>
+    </xs:complexContent>
+  </xs:complexType>
+
+  <!-- NOT MIXED: restricting a mixed type (implicit) -->
+  <xs:complexType name="NOTMIXED_implicitRestrictMixedType">
+    <xs:complexContent>
+      <xs:restriction base="MIXED_explicit">
+      </xs:restriction>
+  </xs:complexContent>
+  </xs:complexType>
+</xs:schema>

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -165,6 +165,9 @@ type ComplexType struct {
 	// this type is derived by restricting the set of elements and
 	// attributes allowed in Base.
 	Extends bool
+	// If true, this type is allowed to contain character data that is
+	// not part of any sub-element.
+	Mixed bool
 }
 
 func (*ComplexType) isType() {}

--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -3,6 +3,7 @@ package xsd
 import (
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -14,22 +15,54 @@ func glob(dir ...string) []string {
 	return files
 }
 
+func parseFile(t *testing.T, name string) []Schema {
+	data, err := ioutil.ReadFile(name)
+	if err != nil {
+		panic(err)
+	}
+	s, err := Parse(data)
+	if err != nil {
+		t.Error(err)
+		t.Logf("%#v", s[0].Types)
+		return nil
+	}
+	return s
+}
+
 func TestParse(t *testing.T) {
 	for _, file := range glob("testdata/*") {
-		data, err := ioutil.ReadFile(file)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-		t.Logf("Parse %s", file)
-
-		schemaList, err := Parse(data)
-		if err != nil {
-			t.Error(err)
-			continue
-		}
-		for _, s := range schemaList {
+		for _, s := range parseFile(t, file) {
 			t.Logf("Parsed namespace %q with %d types", s.TargetNS, len(s.Types))
+		}
+	}
+}
+
+func TestMixedContentModel(t *testing.T) {
+	const tns = "http://example.net"
+	for _, schema := range parseFile(t, "testdata/mixed.xsd") {
+		if schema.TargetNS != tns {
+			continue
+		}
+		for name, typ := range schema.Types {
+			if name.Space != tns {
+				continue
+			}
+			c, ok := typ.(*ComplexType)
+			if !ok {
+				t.Logf("Skipping %T %s", typ, name.Local)
+				continue
+			}
+			if strings.HasPrefix(name.Local, "NOTMIXED") {
+				if c.Mixed {
+					t.Errorf("got %s Mixed=true, wanted false",
+						name.Local)
+				}
+			} else {
+				if !c.Mixed {
+					t.Errorf("got %s Mixed=false, wanted true",
+						name.Local)
+				}
+			}
 		}
 	}
 }

--- a/xsdgen/testdata/mixed-complex.xsd
+++ b/xsdgen/testdata/mixed-complex.xsd
@@ -1,0 +1,20 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ns="http://example.org" targetNamespace="http://example.org">
+
+  <xs:complexType name="Number">
+    <xs:simpleContent>
+      <xs:extension base="xs:double">
+        <xs:attribute name="precision" type="xs:int"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="PositiveNumber">
+    <xs:simpleContent>
+      <xs:restriction base="ns:Number">
+        <xs:minInclusive value="1"/>
+      </xs:restriction>
+    </xs:simpleContent>
+  </xs:complexType>
+
+</xs:schema>
+


### PR DESCRIPTION
This should fix issue #9, in which xsdgen fails to generate proper Go type declarations for types that restrict another type with a mixed content model. In other words, given the following type

	<complexType name="Number">
	  <simpleContent>
	    <extension base="double">
	      <attribute name="precision" type="int" />
	    </extension>
	  </simpleContent>
	</complexType>
	
	Example usage:

	<Number precision=3>1.024</Number>

We obviously care about what comes between the <Number> tags. However for types derived from `Number`, xsdgen would only generate the proper type declarations for types that were derived by extension. This fixes that issue, and introduces the "mixed" property from the XML schema, and propagates it to all derived types following (mostly) the rules of the XML schema spec.