### PR TITLE
marshal xsdDateTime object

### DIFF
--- a/wsdlgen/wsdlgen_test.go
+++ b/wsdlgen/wsdlgen_test.go
@@ -44,7 +44,7 @@ func TestNationalWeatherForecast(t *testing.T) {
 	testGen(t, "../testdata/ndfdXML.wsdl")
 }
 
-func testGlobalWeather(t *testing.T) {
+func TestGlobalWeather(t *testing.T) {
 	testGen(t, "../testdata/webservicex-globalweather-ws.wsdl")
 }
 

--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -293,8 +293,8 @@ func ExampleUseFieldNames() {
 	// func (t *xsdDate) UnmarshalText(text []byte) error {
 	// 	return _unmarshalTime(text, (*time.Time)(t), "2006-01-02")
 	// }
-	// func (t *xsdDate) MarshalText() ([]byte, error) {
-	// 	return []byte((*time.Time)(t).Format("2006-01-02")), nil
+	// func (t xsdDate) MarshalText() ([]byte, error) {
+	// 	return []byte((time.Time)(t).Format("2006-01-02")), nil
 	// }
 	// func _unmarshalTime(text []byte, t *time.Time, format string) (err error) {
 	// 	s := string(bytes.TrimSpace(text))

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -613,10 +613,10 @@ func (cfg *Config) genTimeSpec(t xsd.Builtin) ([]spec, error) {
 		return nil, fmt.Errorf("could not generate unmarshal function for %s: %v", s.name, err)
 	}
 	marshal, err := gen.Func("MarshalText").
-		Receiver("t *"+s.name).
+		Receiver("t "+s.name).
 		Returns("[]byte", "error").
 		Body(`
-			return []byte((*time.Time)(t).Format(%q)), nil
+			return []byte((time.Time)(t).Format(%q)), nil
 		`, timespec).Decl()
 	if err != nil {
 		return nil, fmt.Errorf("could not generate marshal function for %s: %v", s.name, err)


### PR DESCRIPTION
The `xsdDateTime` couldn't be marshalled in XML, however it works if I put it into a slice (have no idea why).

Anyway, this fix should work both on object and pointer receiver.