### PR TITLE
Fix duplication of xmlns attributes when marshalling

### DIFF
--- a/xmltree/marshal.go
+++ b/xmltree/marshal.go
@@ -14,9 +14,7 @@ import (
 var tagTmpl = template.Must(template.New("Marshal XML tags").Parse(
 	`{{define "start" -}}
 	<{{.Scope.Prefix .Name -}}
-	{{range .StartElement.Attr}} {{if .Name.Space -}}
-		{{.Name.Space}}:{{.Name.Local}}{{else}}{{.Name.Local -}}
-	{{end -}}="{{.Value}}"{{end -}}
+	{{range .StartElement.Attr}} {{$.Scope.Prefix .Name -}}="{{.Value}}"{{end -}}
 	{{range .NS }} xmlns{{ if .Local }}:{{ .Local }}{{end}}="{{ .Space }}"{{end}}>
 	{{- end}}
 	

--- a/xmltree/xmltree.go
+++ b/xmltree/xmltree.go
@@ -152,15 +152,16 @@ func (scope *Scope) Prefix(name xml.Name) (qname string) {
 	return qname
 }
 
-func (scope *Scope) pushNS(tag xml.StartElement) {
+func (scope *Scope) pushNS(tag xml.StartElement) []xml.Attr {
 	var ns []xml.Name
+	var newAttrs []xml.Attr
 	for _, attr := range tag.Attr {
 		if attr.Name.Space == "xmlns" {
 			ns = append(ns, xml.Name{attr.Value, attr.Name.Local})
 		} else if attr.Name.Local == "xmlns" {
 			ns = append(ns, xml.Name{attr.Value, ""})
 		} else {
-			continue
+			newAttrs = append(newAttrs, attr)
 		}
 	}
 	if len(ns) > 0 {
@@ -170,6 +171,7 @@ func (scope *Scope) pushNS(tag xml.StartElement) {
 		// being clobbered during parsing.
 		scope.ns = scope.ns[:len(scope.ns):len(scope.ns)]
 	}
+	return newAttrs
 }
 
 // Save some typing when scanning xml
@@ -239,7 +241,7 @@ func (el *Element) parse(scanner *scanner, data []byte, depth int) error {
 	if depth > recursionLimit {
 		return errDeepXML
 	}
-	el.pushNS(el.StartElement)
+	el.StartElement.Attr = el.pushNS(el.StartElement)
 
 	begin := scanner.InputOffset()
 	end := begin

--- a/xmltree/xmltree_test.go
+++ b/xmltree/xmltree_test.go
@@ -321,3 +321,22 @@ func TestCharset(t *testing.T) {
 		t.Logf("%s\n", out)
 	}
 }
+
+func TestExistingNSAttrs(t *testing.T) {
+	root := parseDoc(t, exampleDoc)
+
+	// marshal it to duplicate the scope ns into the existing attrs
+	out := Marshal(root)
+
+	// Parse that again so we can inspect the results
+	root = parseDoc(t, out)
+
+	// Check for any duplicate attributes
+	found := map[xml.Name]bool{}
+	for _, attr := range root.StartElement.Attr {
+		if found[attr.Name] {
+			t.Fatalf("Found duplicate attribute: %v", attr)
+		}
+		found[attr.Name] = true
+	}
+}


### PR DESCRIPTION
Previously the `xmlns` attributes would end up in both `Element.Scope.NS` and in `Element.StartElement.Attr`, so when you called `Marshal(root)`, you would get duplicates, which causes `encoding/xml.Unmarshal` to error.

Edit:
I've also added a commit to resolve prefixes on attributes. Without this, I was seeing attributes like:
```
<p:sldId id="256" http://schemas.openxmlformats.org/officeDocument/2006/relationships:id="rId2"></p:sldId>
```
instead of:
```
<p:sldId id="256" r:id="rId2"></p:sldId>
```
I wasn't sure of a good way to write a test for this, but can have more of a think about that if you prefer.