### PR TITLE
Add marshal/unmarshal tests for generated Go code.

### DIFF
--- a/xmltree/compare.go
+++ b/xmltree/compare.go
@@ -1,0 +1,68 @@
+package xmltree
+
+import (
+	"bytes"
+	"encoding/xml"
+	"sort"
+)
+
+// Equal returns true if two xmltree.Elements are equal, ignoring
+// differences in white space, sub-element order, and namespace prefixes.
+func Equal(a, b *Element) bool {
+	return equal(a, b, 0)
+}
+
+type byName []Element
+
+func (l byName) Len() int { return len(l) }
+func (l byName) Less(i, j int) bool {
+	return l[i].Name.Space+l[i].Name.Local < l[j].Name.Space+l[j].Name.Local
+}
+func (l byName) Swap(i, j int) { l[i], l[j] = l[j], l[i] }
+
+func equal(a, b *Element, depth int) bool {
+	const maxDepth = 1000
+	if depth > maxDepth {
+		return false
+	}
+	if !equalElement(a, b) {
+		return false
+	}
+	if len(a.Children) != len(b.Children) {
+		return false
+	}
+	if len(a.Children) == 0 {
+		return bytes.Equal(bytes.TrimSpace(a.Content), bytes.TrimSpace(b.Content))
+	}
+	sort.Sort(byName(a.Children))
+	sort.Sort(byName(b.Children))
+	for i := range a.Children {
+		if !equal(&a.Children[i], &b.Children[i], depth+1) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalElement(a, b *Element) bool {
+	if a.Name != b.Name {
+		return false
+	}
+	attrs := make(map[xml.Name]string)
+	for _, a := range a.StartElement.Attr {
+		if a.Name.Space == "xmlns" || a.Name.Local == "xmlns" {
+			continue
+		}
+		attrs[a.Name] = a.Value
+	}
+
+	for _, a := range b.StartElement.Attr {
+		if a.Name.Space == "xmlns" || a.Name.Local == "xmlns" {
+			continue
+		}
+		if v, ok := attrs[a.Name]; !ok || v != a.Value {
+			return false
+		}
+	}
+	return true
+}

--- a/xsdgen/_testgen/testgen.go
+++ b/xsdgen/_testgen/testgen.go
@@ -1,0 +1,200 @@
+// testgen is a wrapper around xsdgen that generates unit
+// for generated code.
+package main
+
+import (
+	"encoding/xml"
+	"flag"
+	"fmt"
+	"go/ast"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"aqwari.net/xml/internal/gen"
+	"aqwari.net/xml/xmltree"
+	"aqwari.net/xml/xsdgen"
+)
+
+var (
+	output = flag.String("o", "gen_test.go", "test filename ending")
+	pkg    = flag.String("pkg", "", "name of test's package")
+)
+
+func main() {
+	cfg := new(xsdgen.Config)
+
+	flag.Parse()
+	if flag.NArg() != 1 {
+		log.Fatal("usage: testgen [-o outfile] dir")
+	}
+	if *pkg == "" {
+		*pkg = os.Getenv("GOPACKAGE")
+	}
+	cases := findTestCases(flag.Arg(0))
+
+	cfg.Option(xsdgen.DefaultOptions...)
+	cfg.Option(
+		xsdgen.PackageName(*pkg),
+	)
+	for _, stem := range cases {
+		data, err := ioutil.ReadFile(stem + ".xsd")
+		if err != nil {
+			log.Print(err)
+			continue
+		}
+		tests, err := genTests(cfg, data, stem+".xml")
+		if err != nil {
+			log.Print(stem, ":", err)
+			continue
+		}
+		source, err := gen.FormattedSource(tests)
+		if err != nil {
+			log.Print(stem, ":", err)
+			continue
+		}
+		filename := filepath.Base(stem) + "_" + *output
+		if err := ioutil.WriteFile(filename, source, 0666); err != nil {
+			log.Print(stem, ":", err)
+		}
+	}
+}
+
+// Generates unit tests for xml marshal unmarshalling of
+// schema-generated code. The unit test will do the
+// following:
+//
+// - Unmarshal the sample data (dataFile) into a struct representing
+//   the document described in the XML schema.
+// - Marshal the resulting file back into an XML document.
+// - Compare the two documents for equality.
+func genTests(cfg *xsdgen.Config, data []byte, dataFile string) (*ast.File, error) {
+	base := filepath.Base(dataFile)
+	base = base[:len(base)-len(filepath.Ext(base))]
+
+	code, err := cfg.GenCode(data)
+	if err != nil {
+		return nil, err
+	}
+	file, err := code.GenAST()
+	if err != nil {
+		return nil, err
+	}
+
+	// We look for top-level elements in the schema to determine what
+	// the example document looks like.
+	root, err := xmltree.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	doc := topLevelElements(root)
+	fields := make([]ast.Expr, 0, len(doc)*3)
+
+	for _, elem := range doc {
+		fields = append(fields,
+			gen.Public(elem.Name.Local),
+			ast.NewIdent(code.NameOf(elem.Type)),
+			gen.String(fmt.Sprintf(`xml:"%s %s"`, elem.Name.Space, elem.Name.Local)))
+	}
+	expr, err := gen.ToString(gen.Struct(fields...))
+	if err != nil {
+		return nil, err
+	}
+
+	var params struct {
+		DocStruct string
+		DataFile  string
+	}
+	params.DocStruct = expr
+	params.DataFile = dataFile
+	fn, err := gen.Func("Test"+strings.Title(base)).
+		Args("t *testing.T").
+		BodyTmpl(`
+			type Document {{.DocStruct}}
+			var document Document
+			input, err := ioutil.ReadFile("{{.DataFile}}")
+			if err != nil {
+				t.Fatal(err)
+			}
+			input = append([]byte("<Document>\n"), input...)
+			input = append(input, []byte("</Document>")...)
+			if err := xml.Unmarshal(input, &document); err != nil {
+				t.Fatal("unmarshal: ", err)
+			}
+			output, err := xml.Marshal(&document)
+			if err != nil {
+				t.Fatal("marshal: ", err)
+			}
+			
+			inputTree, err := xmltree.Parse(input)
+			if err != nil {
+				t.Fatal("{{.DataFile}}: ", err)
+			}
+			
+			outputTree, err := xmltree.Parse(output)
+			if err != nil {
+				t.Fatal("remarshal: ", err)
+			}
+			
+			if !xmltree.Equal(inputTree, outputTree) {
+				t.Errorf("got \n%s\n, wanted \n%s\n",
+					xmltree.MarshalIndent(outputTree, "", "  "),
+					xmltree.MarshalIndent(inputTree, "", "  "))
+			}
+			`, params).Decl()
+
+	// Test goes at the top
+	file.Decls = append([]ast.Decl{fn}, file.Decls...)
+	return file, nil
+}
+
+type Element struct {
+	Name, Type xml.Name
+}
+
+func topLevelElements(root *xmltree.Element) []Element {
+	const schemaNS = "http://www.w3.org/2001/XMLSchema"
+
+	result := make([]Element, 0)
+	root = &xmltree.Element{Scope: root.Scope, Children: []xmltree.Element{*root}}
+	for _, schema := range root.Search(schemaNS, "schema") {
+		tns := schema.Attr("", "targetNamespace")
+		for _, el := range schema.Children {
+			if (el.Name == xml.Name{schemaNS, "element"}) {
+				result = append(result, Element{
+					Name: el.ResolveDefault(el.Attr("", "name"), tns),
+					Type: el.Resolve(el.Attr("", "type")),
+				})
+			}
+			break
+		}
+	}
+	return result
+}
+
+// Looks for pairs of (xml, xsd) files in a directory, that
+// should contain xml data and the schema that describes
+// it, respectively. Returns slice of file names with extension
+// removed.
+func findTestCases(dir string) []string {
+	filenames, err := filepath.Glob(filepath.Join(dir, "*.xml"))
+	if err != nil {
+		return nil
+	}
+	testCases := make([]string, 0, len(filenames))
+	for _, xmlfile := range filenames {
+		ext := filepath.Ext(xmlfile)
+		if len(ext) == len(xmlfile) {
+			continue
+		}
+		base := xmlfile[:len(xmlfile)-len(ext)]
+		schemafile := base + ".xsd"
+		if _, err := os.Stat(schemafile); err != nil {
+			continue
+		}
+		testCases = append(testCases, base)
+	}
+	return testCases
+}

--- a/xsdgen/bindata_gen_test.go
+++ b/xsdgen/bindata_gen_test.go
@@ -1,0 +1,104 @@
+package xsdgen
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/xml"
+	"io/ioutil"
+	"testing"
+
+	"aqwari.net/xml/xmltree"
+)
+
+func TestBindata(t *testing.T) {
+	type Document struct {
+		Bindata Bindata `xml:"tns bindata"`
+	}
+	var document Document
+	input, err := ioutil.ReadFile("testdata/bindata.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	input = append([]byte("<Document>\n"), input...)
+	input = append(input, []byte("</Document>")...)
+	if err := xml.Unmarshal(input, &document); err != nil {
+		t.Fatal("unmarshal: ", err)
+	}
+	output, err := xml.Marshal(&document)
+	if err != nil {
+		t.Fatal("marshal: ", err)
+	}
+	inputTree, err := xmltree.Parse(input)
+	if err != nil {
+		t.Fatal("testdata/bindata.xml: ", err)
+	}
+	outputTree, err := xmltree.Parse(output)
+	if err != nil {
+		t.Fatal("remarshal: ", err)
+	}
+	if !xmltree.Equal(inputTree, outputTree) {
+		t.Errorf("got \n%s\n, wanted \n%s\n", xmltree.MarshalIndent(outputTree, "", "  "), xmltree.MarshalIndent(inputTree, "", "  "))
+	}
+}
+
+type Bindata struct {
+	HexData  []byte `xml:"tns hexData"`
+	B64Data  []byte `xml:"tns b64Data"`
+	Filename string `xml:"tns filename"`
+}
+
+func (t *Bindata) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type T Bindata
+	var layout struct {
+		*T
+		HexData xsdHexBinary    `xml:"tns hexData"`
+		B64Data xsdBase64Binary `xml:"tns b64Data"`
+	}
+	layout.T = (*T)(t)
+	layout.HexData = xsdHexBinary(layout.T.HexData)
+	layout.B64Data = xsdBase64Binary(layout.T.B64Data)
+	return e.EncodeElement(layout, start)
+}
+func (t *Bindata) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type T Bindata
+	var overlay struct {
+		*T
+		HexData xsdHexBinary    `xml:"tns hexData"`
+		B64Data xsdBase64Binary `xml:"tns b64Data"`
+	}
+	overlay.T = (*T)(t)
+	if err := d.DecodeElement(&overlay, &start); err != nil {
+		return err
+	}
+	overlay.T.HexData = []byte(overlay.HexData)
+	overlay.T.B64Data = []byte(overlay.B64Data)
+	return nil
+}
+
+type xsdBase64Binary []byte
+
+func (b *xsdBase64Binary) UnmarshalText(text []byte) (err error) {
+	*b, err = base64.StdEncoding.DecodeString(string(text))
+	return
+}
+func (b xsdBase64Binary) MarshalText() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := base64.NewEncoder(base64.StdEncoding, &buf)
+	enc.Write([]byte(b))
+	enc.Close()
+	return buf.Bytes(), nil
+}
+
+type xsdHexBinary []byte
+
+func (b *xsdHexBinary) UnmarshalText(text []byte) (err error) {
+	*b, err = hex.DecodeString(string(text))
+	return
+}
+func (b xsdHexBinary) MarshalText() ([]byte, error) {
+	n := hex.EncodedLen(len(b))
+	buf := make([]byte, n)
+	hex.Encode(buf, []byte(b))
+	return buf, nil
+}

--- a/xsdgen/books_gen_test.go
+++ b/xsdgen/books_gen_test.go
@@ -1,0 +1,97 @@
+package xsdgen
+
+import (
+	"bytes"
+	"encoding/xml"
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"aqwari.net/xml/xmltree"
+)
+
+func TestBooks(t *testing.T) {
+	type Document struct {
+		Books BooksForm `xml:"urn:books books"`
+	}
+	var document Document
+	input, err := ioutil.ReadFile("testdata/books.xml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	input = append([]byte("<Document>\n"), input...)
+	input = append(input, []byte("</Document>")...)
+	if err := xml.Unmarshal(input, &document); err != nil {
+		t.Fatal("unmarshal: ", err)
+	}
+	output, err := xml.Marshal(&document)
+	if err != nil {
+		t.Fatal("marshal: ", err)
+	}
+	inputTree, err := xmltree.Parse(input)
+	if err != nil {
+		t.Fatal("testdata/books.xml: ", err)
+	}
+	outputTree, err := xmltree.Parse(output)
+	if err != nil {
+		t.Fatal("remarshal: ", err)
+	}
+	if !xmltree.Equal(inputTree, outputTree) {
+		t.Errorf("got \n%s\n, wanted \n%s\n", xmltree.MarshalIndent(outputTree, "", "  "), xmltree.MarshalIndent(inputTree, "", "  "))
+	}
+}
+
+type BookForm struct {
+	Name    string    `xml:"name,attr"`
+	Author  string    `xml:"urn:books author"`
+	Title   string    `xml:"urn:books title"`
+	Genre   string    `xml:"urn:books genre"`
+	Price   float32   `xml:"urn:books price"`
+	Pubdate time.Time `xml:"urn:books pub_date"`
+	Review  string    `xml:"urn:books review"`
+}
+
+func (t *BookForm) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	type T BookForm
+	var layout struct {
+		*T
+		Pubdate xsdDate `xml:"urn:books pub_date"`
+	}
+	layout.T = (*T)(t)
+	layout.Pubdate = xsdDate(layout.T.Pubdate)
+	return e.EncodeElement(layout, start)
+}
+func (t *BookForm) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type T BookForm
+	var overlay struct {
+		*T
+		Pubdate xsdDate `xml:"urn:books pub_date"`
+	}
+	overlay.T = (*T)(t)
+	if err := d.DecodeElement(&overlay, &start); err != nil {
+		return err
+	}
+	overlay.T.Pubdate = time.Time(overlay.Pubdate)
+	return nil
+}
+
+type BooksForm struct {
+	Book []BookForm `xml:"urn:books book"`
+}
+
+type xsdDate time.Time
+
+func (t *xsdDate) UnmarshalText(text []byte) error {
+	return _unmarshalTime(text, (*time.Time)(t), "2006-01-02")
+}
+func (t xsdDate) MarshalText() ([]byte, error) {
+	return []byte((time.Time)(t).Format("2006-01-02")), nil
+}
+func _unmarshalTime(text []byte, t *time.Time, format string) (err error) {
+	s := string(bytes.TrimSpace(text))
+	*t, err = time.Parse(format, s)
+	if _, ok := err.(*time.ParseError); ok {
+		*t, err = time.Parse(format+"Z07:00", s)
+	}
+	return err
+}

--- a/xsdgen/testdata/bindata.xml
+++ b/xsdgen/testdata/bindata.xml
@@ -1,0 +1,5 @@
+<bindata xmlns="tns">
+  <hexData>deadbeef</hexData>
+  <b64Data>bG9yZW0gaXBzdW0=</b64Data>
+  <filename>example.bin</filename>
+</bindata>

--- a/xsdgen/testdata/bindata.xsd
+++ b/xsdgen/testdata/bindata.xsd
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:tns="tns"
+  targetNamespace="tns">
+  
+  <element name="bindata" type="tns:bindata" />
+
+  <complexType name="bindata">
+    <element name="hexData" type="hexBinary"/>
+    <element name="b64Data" type="base64Binary"/>
+    <element name="filename" type="string"/>
+  </complexType>
+</schema>

--- a/xsdgen/testdata/books.xml
+++ b/xsdgen/testdata/books.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<books xmlns="urn:books">
+   <book name="bk001">
+      <author>Writer</author>
+      <title>The First Book</title>
+      <genre>Fiction</genre>
+      <price>44.95</price>
+      <pub_date>2000-10-01</pub_date>
+      <review>An amazing story of nothing.</review>
+   </book>
+
+   <book name="bk002">
+      <author>Poet</author>
+      <title>The Poets First Poem</title>
+      <genre>Poem</genre>
+      <price>24.95</price>
+      <review>Least poetic poems.</review>
+      <pub_date>2003-12-01</pub_date>
+   </book>
+</books>

--- a/xsdgen/testdata/books.xsd
+++ b/xsdgen/testdata/books.xsd
@@ -1,0 +1,28 @@
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="urn:books"
+            xmlns:bks="urn:books">
+
+  <xsd:element name="books" type="bks:BooksForm"/>
+
+  <xsd:complexType name="BooksForm">
+    <xsd:sequence>
+      <xsd:element name="book" 
+                  type="bks:BookForm" 
+                  minOccurs="0" 
+                  maxOccurs="unbounded"/>
+      </xsd:sequence>
+  </xsd:complexType>
+
+  <xsd:complexType name="BookForm">
+    <xsd:sequence>
+      <xsd:element name="author"   type="xsd:string"/>
+      <xsd:element name="title"    type="xsd:string"/>
+      <xsd:element name="genre"    type="xsd:string"/>
+      <xsd:element name="price"    type="xsd:float" />
+      <xsd:element name="pub_date" type="xsd:date" />
+      <xsd:element name="review"   type="xsd:string"/>
+    </xsd:sequence>
+    <xsd:attribute name="name"   type="xsd:string"/>
+  </xsd:complexType>
+</xsd:schema>
+

--- a/xsdgen/xsdgen_test.go
+++ b/xsdgen/xsdgen_test.go
@@ -7,6 +7,9 @@ import (
 	"testing"
 )
 
+//go:generate -command testgen go run _testgen/testgen.go
+//go:generate testgen testdata
+
 type testLogger testing.T
 
 func grep(pattern, data string) bool {


### PR DESCRIPTION
To add a new test, create two files in xsdgen/testdata:
- <name>.xsd , containing a single XML schema document.
- <name>.xml, containing sample data conforming to the schema.

Then run 'go generate' in the xsdgen directory. The file name should
be a valid Go identifier, and the schema should list as a top-level element
every element in the sample data.

The file <name>_gen_test.go will be generated, containing type declarations
from the schema, and a unit test function, Test<Name>, that does the following:

- Declares a top-level Document struct containing each element described
  in the schema.
- Unmarshals the sample file into said struct.
- Marshals said struct back into XML.
- Confirms that the output XML is equivalent to the input XML.

The `xmltree.Equal` method was added for this purpose; it disregards order,
leading/trailing white space, and different namespace prefixes when comparing
two documents.

First step towards closing #25 