### PR TITLE
Reduce redundant xmlns declarations

### DIFF
--- a/xmltree/marshal.go
+++ b/xmltree/marshal.go
@@ -135,8 +135,9 @@ func diffScope(parent, child *Element) Scope {
 		if childScope.ns[0] == parentScope.ns[0] {
 			childScope.ns = childScope.ns[1:]
 			parentScope.ns = parentScope.ns[1:]
+		} else {
+			break
 		}
-		break
 	}
 	return childScope
 }


### PR DESCRIPTION
* Fix a regression in `diffScope` function that only removed first common xmlns element.
* Sort xmlns declarations at each level, to increase chance of similarities