### PR TITLE
Name anonymous types after containing elements/attributes

### DIFF
--- a/xsd/testdata/Anonymous.json
+++ b/xsd/testdata/Anonymous.json
@@ -1,5 +1,5 @@
 {
-  "_anon1": {
+  "someElement": {
     "Elements": [{"Name": {"Local": "Field1"}, "Type": 38}],
     "Attributes": [{"Name": {"Local": "Attr1"}, "Type": 28}]
   }


### PR DESCRIPTION
Generated names for anonymous types are ugly, so we should avoid them
when we can.

Helps with (but does not resolve) #14 