### PR TITLE
fix imports.Process call

### DIFF
--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -424,7 +424,7 @@ func TagKey(field *ast.Field, key string) string {
 
 // FormattedSource converts an abstract syntax tree to
 // formatted Go source code.
-func FormattedSource(file *ast.File) ([]byte, error) {
+func FormattedSource(file *ast.File, output string) ([]byte, error) {
 	var buf bytes.Buffer
 
 	fileset := token.NewFileSet()
@@ -446,7 +446,7 @@ func FormattedSource(file *ast.File) ([]byte, error) {
 	if err := format.Node(&buf, fileset, file); err != nil {
 		return nil, err
 	}
-	out, err := imports.Process("", buf.Bytes(), nil)
+	out, err := imports.Process(output, buf.Bytes(), nil)
 	if err != nil {
 		return nil, fmt.Errorf("%v in %s", err, buf.String())
 	}

--- a/wsdlgen/cli.go
+++ b/wsdlgen/cli.go
@@ -19,7 +19,7 @@ func (cfg *Config) GenSource(files ...string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return gen.FormattedSource(file)
+	return gen.FormattedSource(file, "fixme.go")
 }
 
 // GenCLI creates a file containing Go source generated from a WSDL
@@ -67,7 +67,7 @@ func (cfg *Config) GenCLI(arguments ...string) error {
 		return err
 	}
 
-	data, err := gen.FormattedSource(file)
+	data, err := gen.FormattedSource(file, *output)
 	if err != nil {
 		return err
 	}

--- a/xsdgen/cli.go
+++ b/xsdgen/cli.go
@@ -67,7 +67,7 @@ func (cfg *Config) GenSource(files ...string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return gen.FormattedSource(file)
+	return gen.FormattedSource(file, "fixme.go")
 }
 
 // GenCLI creates a file containing Go source generated from an XML
@@ -111,7 +111,7 @@ func (cfg *Config) GenCLI(arguments ...string) error {
 		return err
 	}
 
-	data, err := gen.FormattedSource(file)
+	data, err := gen.FormattedSource(file, *output)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
On Windows I was getting an error for invalid filename in this call. I'm under the impression that this error may not happen on Linux.