### PR TITLE
Don't overwrite linked objects when flattening references.

### DIFF
--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -365,7 +365,7 @@ func flattenRef(schema []*xmltree.Element) error {
 func deref(ref, real *xmltree.Element) *xmltree.Element {
 	attrs := ref.StartElement.Attr
 	ref.Content = real.Content
-	ref.StartElement = real.StartElement
+	ref.StartElement = real.StartElement.Copy()
 	ref.Children = append([]xmltree.Element{}, real.Children...)
 	ref.Scope = *real.JoinScope(&ref.Scope)
 	for _, attr := range attrs {

--- a/xsd/testdata/AttributeGroup.json
+++ b/xsd/testdata/AttributeGroup.json
@@ -1,5 +1,8 @@
 {
   "myElementType": {
+    "Elements": [
+      {"Name": {"Local": "Field1"}, "Type": 38}
+    ],
     "Attributes": [
       {"Name": {"Local": "someattribute1"}, "Type": 29},
       {"Name": {"Local": "someattribute2"}, "Type": 38}

--- a/xsd/testdata/AttributeGroup.xsd
+++ b/xsd/testdata/AttributeGroup.xsd
@@ -3,10 +3,13 @@
   is represented as a type that contains all the attributes in said group.
 -->
 <attributeGroup name="myAttributeGroup">
-    <attribute name="someattribute1" type="integer"/>
-    <attribute name="someattribute2" type="string"/>
+  <attribute name="someattribute1" type="integer"/>
+  <attribute name="someattribute2" type="string"/>
 </attributeGroup>
 
 <complexType name="myElementType">
-    <attributeGroup ref="tns:myAttributeGroup"/>
+  <attributeGroup ref="tns:myAttributeGroup"/>
+  <element name="Field1" ref="tns:SomeElement" />
 </complexType>
+
+<element name="SomeElement" type="string" />


### PR DESCRIPTION
Fixes #41