### PR TITLE
Unnest anonymous types

### DIFF
--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -216,13 +216,16 @@ func copyEltNamesToAnonTypes(root *xmltree.Element) {
 			continue
 		}
 		used[xmlname] = struct{}{}
-		for i := range el.Children {
-			t := &el.Children[i]
-			if !isAnonymousType(t) {
+		for i, t := range el.Children {
+			if !isAnonymousType(&t) {
 				continue
 			}
 			t.SetAttr("", "name", el.Attr("", "name"))
 			el.SetAttr("", "type", el.Prefix(xmlname))
+
+			el.Children = append(el.Children[:i], el.Children[i+1:]...)
+			el.Content = nil
+			root.Children = append(root.Children, t)
 			break
 		}
 	}
@@ -281,9 +284,8 @@ func nameAnonymousTypes(root *xmltree.Element) error {
 			return fmt.Errorf("Did not expect <%s> to have an anonymous type",
 				el.Prefix(el.Name))
 		}
-		for i := range el.Children {
-			t := &el.Children[i]
-			if !isAnonymousType(t) {
+		for i, t := range el.Children {
+			if !isAnonymousType(&t) {
 				continue
 			}
 			typeCounter++
@@ -297,6 +299,9 @@ func nameAnonymousTypes(root *xmltree.Element) error {
 				qname = el.Attr("", updateAttr) + " " + qname
 			}
 			el.SetAttr("", updateAttr, qname)
+			el.Children = append(el.Children[:i], el.Children[i+1:]...)
+			el.Content = nil
+			root.Children = append(root.Children, t)
 			if !accum {
 				break
 			}

--- a/xsd/testdata/ComplexType.xsd
+++ b/xsd/testdata/ComplexType.xsd
@@ -5,12 +5,13 @@
     <element name='ContactTitle' type='string'/>
     <element name='Phone' type='string'/>
     <element name='Fax' minOccurs='0' type='string'/>
-    <element name='FullAddress' type='tns:AddressType'/>
+    <element name='FullAddress' ref='tns:AddressType'/>
   </sequence>
   <attribute name='CustomerID' type='token'/>
 </complexType>
 
-<complexType name='AddressType'>
+<element name='AddressType'>
+<complexType>
   <sequence>
     <element name='Address' type='string'/>
     <element name='City' type='string'/>
@@ -20,3 +21,4 @@
   </sequence>
   <attribute name='CustomerID' type='token'/>
 </complexType>
+</element>

--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -304,31 +304,7 @@ func ExampleUseFieldNames() {
 	// }
 	//
 	// type Library struct {
-	// 	Book      []Book    `xml:"http://www.example.com/ book"`
-	// 	Title     string    `xml:"http://www.example.com/ title"`
-	// 	Published time.Time `xml:"http://www.example.com/ published"`
-	// 	Author    string    `xml:"http://www.example.com/ author"`
-	// }
-	//
-	// func (t *Library) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	// 	type T Library
-	// 	var layout struct {
-	// 		*T
-	// 		Published *xsdDate `xml:"http://www.example.com/ published"`
-	// 	}
-	// 	layout.T = (*T)(t)
-	// 	layout.Published = (*xsdDate)(&layout.T.Published)
-	// 	return e.EncodeElement(layout, start)
-	// }
-	// func (t *Library) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	// 	type T Library
-	// 	var overlay struct {
-	// 		*T
-	// 		Published *xsdDate `xml:"http://www.example.com/ published"`
-	// 	}
-	// 	overlay.T = (*T)(t)
-	// 	overlay.Published = (*xsdDate)(&overlay.T.Published)
-	// 	return d.DecodeElement(&overlay, &start)
+	// 	Book []Book `xml:"http://www.example.com/ book"`
 	// }
 	//
 	// type xsdDate time.Time


### PR DESCRIPTION
The `xsd` package already ensures that every type has a name, generating a name if needed. This change ensures all types are declared as direct children of the `<schema>` element. This makes subsequent transforms simpler and less error prone, and should address #41, where nested types were inadvertently duplicated when flattening document references.