### PR TITLE
xsd: fix index out of bounds on range

### DIFF
--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -284,7 +284,9 @@ func nameAnonymousTypes(root *xmltree.Element) error {
 			return fmt.Errorf("Did not expect <%s> to have an anonymous type",
 				el.Prefix(el.Name))
 		}
-		for i, t := range el.Children {
+		for i := 0; i < len(el.Children); i++ {
+			t := el.Children[i]
+
 			if !isAnonymousType(&t) {
 				continue
 			}


### PR DESCRIPTION
This happens because on range, the length is evaluated once, but inside the loop a item can be removed.