### PR TITLE
ensure empty complex types derive from AnyType

### DIFF
--- a/xsd/testdata/EmptyComplexType.json
+++ b/xsd/testdata/EmptyComplexType.json
@@ -1,0 +1,6 @@
+{
+  "Nothingness": {
+    "Doc": "This is an empty type",
+    "Base": 0
+  }
+}

--- a/xsd/testdata/EmptyComplexType.xsd
+++ b/xsd/testdata/EmptyComplexType.xsd
@@ -1,0 +1,5 @@
+<complexType name="Nothingness">
+    <annotation>
+        <documentation>This is an empty type</documentation>
+    </annotation>
+</complexType>


### PR DESCRIPTION
In the issue reported in #50 the `xsd` package produced an invalid Type when given an empty ComplexType declaration. This should fix that issue, and hopefully make the complex shorthand expansion code a little more robust.