### PR TITLE
wsdlgen: wsdl:part with element attributes.

### DIFF
--- a/wsdl/wsdl.go
+++ b/wsdl/wsdl.go
@@ -64,8 +64,8 @@ func (m *Message) String() string {
 // A Part describes the name and type of a parameter to pass
 // to a WSDL endpoint.
 type Part struct {
-	Name string
-	Type xml.Name
+	Name          string
+	Type, Element xml.Name
 }
 
 // An Operation describes an RPC call that can be made against
@@ -104,11 +104,9 @@ func parseMessages(targetNS string, root *xmltree.Element) map[xml.Name]Message 
 		m.Name = msg.ResolveDefault(msg.Attr("", "name"), targetNS)
 		for _, part := range msg.Search(wsdlNS, "part") {
 			p := Part{
-				Name: part.Attr("", "name"),
-				Type: part.Resolve(part.Attr("", "type")),
-			}
-			if len(p.Type.Local) == 0 {
-				p.Type = part.Resolve(part.Attr("", "element"))
+				Name:    part.Attr("", "name"),
+				Type:    part.Resolve(part.Attr("", "type")),
+				Element: part.Resolve(part.Attr("", "element")),
 			}
 			m.Parts = append(m.Parts, p)
 		}

--- a/wsdlgen/wsdlgen_test.go
+++ b/wsdlgen/wsdlgen_test.go
@@ -15,7 +15,6 @@ type testLogger struct {
 func (t testLogger) Printf(format string, args ...interface{}) { t.Logf(format, args...) }
 
 func testGen(t *testing.T, files ...string) {
-	t.Helper()
 	output_file, err := ioutil.TempFile("", "wsdlgen")
 	if err != nil {
 		t.Fatal(err)

--- a/wsdlgen/wsdlgen_test.go
+++ b/wsdlgen/wsdlgen_test.go
@@ -15,11 +15,12 @@ type testLogger struct {
 func (t testLogger) Printf(format string, args ...interface{}) { t.Logf(format, args...) }
 
 func testGen(t *testing.T, files ...string) {
-	file, err := ioutil.TempFile("", "wsdlgen")
+	t.Helper()
+	output_file, err := ioutil.TempFile("", "wsdlgen")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(file.Name())
+	defer os.Remove(output_file.Name())
 
 	var cfg Config
 	cfg.Option(DefaultOptions...)
@@ -27,13 +28,13 @@ func testGen(t *testing.T, files ...string) {
 	cfg.xsdgen.Option(xsdgen.DefaultOptions...)
 	cfg.xsdgen.Option(xsdgen.UseFieldNames())
 
-	args := []string{"-v", "-o", file.Name()}
+	args := []string{"-vv", "-o", output_file.Name()}
 	err = cfg.GenCLI(append(args, files...)...)
 	if err != nil {
 		t.Error(err)
 		return
 	}
-	if data, err := ioutil.ReadFile(file.Name()); err != nil {
+	if data, err := ioutil.ReadFile(output_file.Name()); err != nil {
 		t.Error(err)
 	} else {
 		t.Logf("\n%s\n", data)

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -79,6 +79,14 @@ type Code struct {
 	types map[xml.Name]xsd.Type
 }
 
+// DocType retrieves the complexType for the provided target
+// namespace.
+func (c *Code) DocType(targetNS string) (*xsd.ComplexType, bool) {
+	key := xml.Name{targetNS, "_self"}
+	doc, ok := c.types[key].(*xsd.ComplexType)
+	return doc, ok
+}
+
 // NameOf returns the Go identifier associated with the canonical
 // XML type.
 func (c *Code) NameOf(name xml.Name) string {
@@ -361,6 +369,9 @@ func (cfg *Config) flatten(types map[xml.Name]xsd.Type) []xsd.Type {
 		result = append(result, t)
 	}
 	for _, t := range types {
+		if xsd.XMLName(t).Local == "_self" {
+			continue
+		}
 		cfg.debugf("flattening type %T(%s)\n", t, xsd.XMLName(t).Local)
 		if cfg.filterTypes != nil && cfg.filterTypes(t) {
 			continue


### PR DESCRIPTION
This addresses #14. Now all parsed `xsd.Schema` have an additional entry
in their `Types` map: `tns:_self`. This is a `*ComplexType` with all
top-level elements in its `Elements` list. The `wsdlgen` package has
been updated to lookup the type of elements named in a `wsdl:part` field.