### PR TITLE
Avoid duplicate types resulting from UseFieldNames option.

### DIFF
--- a/xsdgen/config.go
+++ b/xsdgen/config.go
@@ -298,6 +298,10 @@ func UseFieldNames() Option {
 }
 
 func useFieldNames(s xsd.Schema, t xsd.Type) xsd.Type {
+	used := make(map[xml.Name]struct{})
+	for _, t := range s.Types {
+		used[xsd.XMLName(t)] = struct{}{}
+	}
 	c, ok := t.(*xsd.ComplexType)
 	if !ok {
 		return t
@@ -312,6 +316,9 @@ func useFieldNames(s xsd.Schema, t xsd.Type) xsd.Type {
 			base.Anonymous = false
 		case *xsd.ComplexType:
 			if !base.Anonymous {
+				break
+			}
+			if _, inuse := used[el.Name]; inuse {
 				break
 			}
 			base.Name = el.Name


### PR DESCRIPTION
We may be able to remove UseFieldNames altogether, since the
xsd package already has this behavior. However, this is a smaller
change and fixes #56 .