### PR TITLE
Flatten and generate code for parents of complex types.

### DIFF
--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -179,10 +179,10 @@ func ExampleHandleSOAPArrayType() {
 	// Output: package ws
 	//
 	// type BoolArray struct {
-	// 	Items  []bool          `xml:",any"`
-	// 	Offset ArrayCoordinate `xml:"offset,attr,omitempty"`
-	// 	Id     string          `xml:"id,attr,omitempty"`
-	// 	Href   string          `xml:"href,attr,omitempty"`
+	// 	Items  []bool `xml:",any"`
+	// 	Offset string `xml:"offset,attr,omitempty"`
+	// 	Id     string `xml:"id,attr,omitempty"`
+	// 	Href   string `xml:"href,attr,omitempty"`
 	// }
 }
 

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -497,8 +497,13 @@ func (cfg *Config) flatten1(t xsd.Type, push func(xsd.Type), depth int) xsd.Type
 			cfg.debugf("attribute %s %T(%s): %v", attr.Name.Local, t,
 				xsd.XMLName(t).Local, xsd.XMLName(attr.Type))
 		}
+
+		t.Base = cfg.flatten1(t.Base, push, depth+1)
+		push(t.Base)
+
 		cfg.debugf("%T(%s) -> %T(%s)", t, xsd.XMLName(t).Local,
 			t.Base, xsd.XMLName(t.Base).Local)
+
 		return t
 	case xsd.Builtin:
 		return t

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -499,7 +499,15 @@ func (cfg *Config) flatten1(t xsd.Type, push func(xsd.Type), depth int) xsd.Type
 		}
 
 		t.Base = cfg.flatten1(t.Base, push, depth+1)
-		push(t.Base)
+
+		// We expand all complexTypes to merge all of the fields from
+		// their ancestors, so generated code has no dependencies
+		// on ancestor types. The only exception is when the type
+		// has a mixed content model; we need to pull in the type
+		// of its chardata.
+		if t.Mixed {
+			push(t.Base)
+		}
 
 		cfg.debugf("%T(%s) -> %T(%s)", t, xsd.XMLName(t).Local,
 			t.Base, xsd.XMLName(t.Base).Local)


### PR DESCRIPTION
More often than not, a complex type is derived from another
complex type, and during the code gen process, it is simplified
to derive from anyType, and there are no additional types to pull
in.

This fixes issues with missing types for schema that meet the
following criteria:

* There are complexTypes derived from simpleTypes (using simpleContent).
* The simpleTypes are not used anywhere else.
* The simpleTypes are simplified to builtin types because they are
  not interesting enough.