### PR TITLE
all: clarify import locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 [![GoDoc](https://godoc.org/aqwari.net/xml?status.svg)](https://godoc.org/aqwari.net/xml) [![Build Status](https://travis-ci.org/droyo/go-xml.svg?branch=master)](https://travis-ci.org/droyo/go-xml)
 
+## Installation
+```
+go get aqwari.net/xml/...
+```
+
 This repository contains a collection of Go packages for working
 with XML, with the ultimate goal of enabling code generation based
 on XML documents.

--- a/cmd/wsdlgen/wsdlgen.go
+++ b/cmd/wsdlgen/wsdlgen.go
@@ -1,4 +1,4 @@
-package main
+package main // import "aqwari.net/xml/cmd/wsdlgen"
 
 import (
 	"log"

--- a/cmd/xsdgen/doc.go
+++ b/cmd/xsdgen/doc.go
@@ -38,4 +38,4 @@ embed a comment in your go source like so:
 
 	//go:generate xsdgen -ns "http://example.net/ws/" schemafile.xml
 */
-package main
+package main // import "aqwari.net/xml/cmd/xsdgen"

--- a/cmd/xsdparse/xsdparse.go
+++ b/cmd/xsdparse/xsdparse.go
@@ -1,4 +1,4 @@
-package main
+package main // import "aqwari.net/xml/cmd/xsdparse"
 
 import (
 	"flag"

--- a/gentests/gentest.go
+++ b/gentests/gentest.go
@@ -1,5 +1,5 @@
 // Package gentest generates marshal/unmarshal tests for the
 // xsdgen package.
-package gentest
+package gentest // import "aqwari.net/xml/gentests"
 
 //go:generate go run _testgen/testgen.go

--- a/gentests/gentest.go
+++ b/gentests/gentest.go
@@ -1,5 +1,5 @@
 // Package gentest generates marshal/unmarshal tests for the
 // xsdgen package.
-package gentest // import "aqwari.net/xml/gentests"
+package gentests // import "aqwari.net/xml/gentests"
 
 //go:generate go run _testgen/testgen.go

--- a/internal/commandline/cli.go
+++ b/internal/commandline/cli.go
@@ -1,6 +1,6 @@
 // Package commandline contains helper types for collecting
 // command-line arguments.
-package commandline
+package commandline // import "aqwari.net/xml/internal/commandline"
 
 import (
 	"bytes"

--- a/internal/dependency/graph.go
+++ b/internal/dependency/graph.go
@@ -1,5 +1,5 @@
 // Package dependency builds and flattens dependency graphs.
-package dependency
+package dependency // import "aqwari.net/xml/internal/dependency"
 
 import (
 	"sort"

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -2,7 +2,7 @@
 //
 // The gen package provides wrapper functions around the go/ast and
 // go/token packages to reduce boilerplate.
-package gen
+package gen // import "aqwari.net/xml/internal/gen"
 
 import (
 	"bufio"

--- a/wsdl/wsdl.go
+++ b/wsdl/wsdl.go
@@ -1,5 +1,5 @@
 // Package wsdl parses Web Service Definition Language documents.
-package wsdl
+package wsdl // import "aqwari.net/xml/wsdl"
 
 import (
 	"bytes"

--- a/wsdlgen/wsdlgen.go
+++ b/wsdlgen/wsdlgen.go
@@ -7,7 +7,7 @@
 //
 // Code generation for the wsdlgen package can be configured by using
 // the provided Option functions.
-package wsdlgen
+package wsdlgen // import "aqwari.net/xml/wsdlgen"
 
 import (
 	"encoding/xml"


### PR DESCRIPTION
* Note import paths with go get in README.
* Put import comment restrictions on package lacking them.

Please take a look.

Fixes #69.