### PR TITLE
Extend Travis testing to Go 1.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: go
 go_import_path: aqwari.net/xml
 go:
-  - 1.7
+  - "1.7"
+  - "1.8"
+  - "1.9"
+  - "1.10"
+  - "1.11"
 
 notifications:
   email:

--- a/internal/gen/gen.go
+++ b/internal/gen/gen.go
@@ -252,7 +252,7 @@ func (fn *Function) Decl() (*ast.FuncDecl, error) {
 		return nil, errors.New("function name unset")
 	}
 	if len(fn.body) == 0 {
-		return nil, fmt.Errorf("function body for %s unset")
+		return nil, fmt.Errorf("function body for %s unset", fn.name)
 	}
 
 	if fn.godoc != "" {

--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -361,7 +361,7 @@ func flattenRef(schema []*xmltree.Element) error {
 		unpackGroups(doc)
 		if hasCycle(doc, nil) {
 			return fmt.Errorf("cycle detected after flattening references "+
-				"in schema %s:\n%s\n", ns, xmltree.MarshalIndent(doc, "", "  "))
+				"in schema %d:\n%s\n", ns, xmltree.MarshalIndent(doc, "", "  "))
 		}
 	}
 	return nil


### PR DESCRIPTION
Adds more versions to the matrix and fixes a couple of minor bugs which it picked up.