### PR TITLE
Remove support for Go versions before 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: go
 go_import_path: aqwari.net/xml
 go:
-  - "1.7"
-  - "1.8"
   - "1.9"
   - "1.10"
   - "1.11"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 [![GoDoc](https://godoc.org/aqwari.net/xml?status.svg)](https://godoc.org/aqwari.net/xml) [![Build Status](https://travis-ci.org/droyo/go-xml.svg?branch=master)](https://travis-ci.org/droyo/go-xml)
 
 ## Installation
+
+Requires go 1.9 or greater for golang.org/x/html dependency.
+
 ```
 go get aqwari.net/xml/...
 ```


### PR DESCRIPTION
The use of the golang.org/x/imports package depends on the type aliases feature introduced in go1.9.