### PR TITLE
 Pass namespace through to attribute metadata 

### DIFF
--- a/gentests/books/books.xml
+++ b/gentests/books/books.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<books xmlns="urn:books">
-   <book name="bk001">
+<books xmlns="urn:books" xmlns:books="urn:books">
+   <book books:name="bk001">
       <author>Writer</author>
       <title>The First Book</title>
       <genre>Fiction</genre>
@@ -9,7 +9,7 @@
       <review>An amazing story of nothing.</review>
    </book>
 
-   <book name="bk002">
+   <book books:name="bk002">
       <author>Poet</author>
       <title>The Poets First Poem</title>
       <genre>Poem</genre>

--- a/gentests/books/books.xsd
+++ b/gentests/books/books.xsd
@@ -22,7 +22,7 @@
       <xsd:element name="pub_date" type="xsd:date" />
       <xsd:element name="review"   type="xsd:string"/>
     </xsd:sequence>
-    <xsd:attribute name="name"   type="xsd:string"/>
+    <xsd:attribute name="name" form="qualified" type="xsd:string"/>
   </xsd:complexType>
 </xsd:schema>
 

--- a/gentests/books/books_test.go
+++ b/gentests/books/books_test.go
@@ -56,7 +56,7 @@ type BookForm struct {
 	Price   float32   `xml:"urn:books price"`
 	Pubdate time.Time `xml:"urn:books pub_date"`
 	Review  string    `xml:"urn:books review"`
-	Name    string    `xml:"urn:books name,attr,omitempty"`
+	Name    string    `xml:"name,attr,omitempty"`
 }
 
 func (t *BookForm) MarshalXML(e *xml.Encoder, start xml.StartElement) error {

--- a/gentests/books/books_test.go
+++ b/gentests/books/books_test.go
@@ -56,7 +56,7 @@ type BookForm struct {
 	Price   float32   `xml:"urn:books price"`
 	Pubdate time.Time `xml:"urn:books pub_date"`
 	Review  string    `xml:"urn:books review"`
-	Name    string    `xml:"name,attr,omitempty"`
+	Name    string    `xml:"urn:books name,attr,omitempty"`
 }
 
 func (t *BookForm) MarshalXML(e *xml.Encoder, start xml.StartElement) error {

--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -789,6 +789,7 @@ func parseAttribute(ns string, el *xmltree.Element) Attribute {
 	} else {
 		a.Name.Local = name
 	}
+	a.Name.Space = ns
 	a.Type = parseType(el.Resolve(el.Attr("", "type")))
 	a.Default = el.Attr("", "default")
 	a.Scope = el.Scope

--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -153,7 +153,7 @@ func ExampleReplace() {
 	//
 	// type StringArray struct {
 	// 	Items     []string `xml:",any"`
-	// 	ArrayType string   `xml:"arrayType,attr,omitempty"`
+	// 	ArrayType string   `xml:"http://www.example.com/ arrayType,attr,omitempty"`
 	// }
 }
 
@@ -180,9 +180,9 @@ func ExampleHandleSOAPArrayType() {
 	//
 	// type BoolArray struct {
 	// 	Items  []bool `xml:",any"`
-	// 	Offset string `xml:"offset,attr,omitempty"`
-	// 	Id     string `xml:"id,attr,omitempty"`
-	// 	Href   string `xml:"href,attr,omitempty"`
+	// 	Offset string `xml:"http://schemas.xmlsoap.org/soap/encoding/ offset,attr,omitempty"`
+	// 	Id     string `xml:"http://schemas.xmlsoap.org/soap/encoding/ id,attr,omitempty"`
+	// 	Href   string `xml:"http://schemas.xmlsoap.org/soap/encoding/ href,attr,omitempty"`
 	// }
 }
 

--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -153,7 +153,7 @@ func ExampleReplace() {
 	//
 	// type StringArray struct {
 	// 	Items     []string `xml:",any"`
-	// 	ArrayType string   `xml:"http://www.example.com/ arrayType,attr,omitempty"`
+	// 	ArrayType string   `xml:"arrayType,attr,omitempty"`
 	// }
 }
 
@@ -180,9 +180,9 @@ func ExampleHandleSOAPArrayType() {
 	//
 	// type BoolArray struct {
 	// 	Items  []bool `xml:",any"`
-	// 	Offset string `xml:"http://schemas.xmlsoap.org/soap/encoding/ offset,attr,omitempty"`
-	// 	Id     string `xml:"http://schemas.xmlsoap.org/soap/encoding/ id,attr,omitempty"`
-	// 	Href   string `xml:"http://schemas.xmlsoap.org/soap/encoding/ href,attr,omitempty"`
+	// 	Offset string `xml:"offset,attr,omitempty"`
+	// 	Id     string `xml:"id,attr,omitempty"`
+	// 	Href   string `xml:"href,attr,omitempty"`
 	// }
 }
 

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -728,7 +728,18 @@ func (cfg *Config) genComplexType(t *xsd.ComplexType) ([]spec, error) {
 		if attr.Optional {
 			options = ",omitempty"
 		}
-		tag := fmt.Sprintf(`xml:"%s %s,attr%s"`, attr.Name.Space, attr.Name.Local, options)
+		qualified := false
+		for _, attrAttr := range attr.Attr {
+			if attrAttr.Name.Space == "" && attrAttr.Name.Local == "form" && attrAttr.Value == "qualified" {
+				qualified = true
+			}
+		}
+		var tag string
+		if qualified {
+			tag = fmt.Sprintf(`xml:"%s %s,attr%s"`, attr.Name.Space, attr.Name.Local, options)
+		} else {
+			tag = fmt.Sprintf(`xml:"%s,attr%s"`, attr.Name.Local, options)
+		}
 		base, err := cfg.expr(attr.Type)
 		if err != nil {
 			return nil, fmt.Errorf("%s attribute %s: %v", t.Name.Local, attr.Name.Local, err)

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -728,7 +728,7 @@ func (cfg *Config) genComplexType(t *xsd.ComplexType) ([]spec, error) {
 		if attr.Optional {
 			options = ",omitempty"
 		}
-		tag := fmt.Sprintf(`xml:"%s,attr%s"`, attr.Name.Local, options)
+		tag := fmt.Sprintf(`xml:"%s %s,attr%s"`, attr.Name.Space, attr.Name.Local, options)
 		base, err := cfg.expr(attr.Type)
 		if err != nil {
 			return nil, fmt.Errorf("%s attribute %s: %v", t.Name.Local, attr.Name.Local, err)


### PR DESCRIPTION
This attempts to address https://github.com/droyo/go-xml/issues/80

It seemed to do the right thing on my WSDL files, but I'm not 100% certain the behaviour is perfect.
I've updated the test cases and generated code to match the new output, but I don't know if it's correct.