### PR TITLE
Fix NS tags on linked complexTypes

### DIFF
--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -775,6 +775,9 @@ func parseElement(ns string, el *xmltree.Element) Element {
 			doc = doc.append(parseAnnotation(el))
 		}
 	})
+	t, ok := e.Type.(linkedType); if ok {
+		e.Name.Space = t.Space
+	}
 	e.Doc = string(doc)
 	e.Attr = el.StartElement.Attr
 	return e

--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -106,7 +106,7 @@ func ExampleIgnoreElements() {
 	//
 	// type Person struct {
 	// 	Name     string `xml:"http://www.example.com/ name"`
-	// 	Deceased bool   `xml:"http://www.example.com/ deceased"`
+	// 	Deceased bool   `xml:"http://schemas.xmlsoap.org/soap/encoding/ deceased"`
 	// }
 }
 


### PR DESCRIPTION
Fixes issue where elements within a complexType took the namespace of the parent schema instead of the namespace of the element.