### PR TITLE
Revert "Fix sequence order, optional structs as pointers, elements inside choice are optional"

### DIFF
--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -110,9 +110,6 @@ func Normalize(docs ...[]byte) ([]*xmltree.Element, error) {
 		if err := nameAnonymousTypes(root); err != nil {
 			return nil, err
 		}
-		if err := setChoicesOptional(root); err != nil {
-			return nil, err
-		}
 	}
 	for _, root := range result {
 		expandComplexShorthand(root)
@@ -232,31 +229,6 @@ func copyEltNamesToAnonTypes(root *xmltree.Element) {
 			break
 		}
 	}
-}
-
-// Inside a <xs:choice>, set all children to optional
-// If child is a <xs:sequence> set its children to optional
-func setChoicesOptional(root *xmltree.Element) error {
-
-	for _, el := range root.SearchFunc(isElem(schemaNS, "choice")) {
-		for i := 0; i < len(el.Children); i++ {
-			t := el.Children[i]
-
-			if t.Name.Space == schemaNS && t.Name.Local == "sequence" {
-				for j := 0; j < len(t.Children); j++ {
-					t2 := t.Children[j]
-					t2.SetAttr("", "minOccurs", "0")
-					t.Children[j] = t2
-				}
-			} else {
-				t.SetAttr("", "minOccurs", "0")
-			}
-
-			el.Children[i] = t
-		}
-	}
-
-	return nil
 }
 
 /*

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -322,19 +322,14 @@ func (cfg *Config) expandComplexTypes(types []xsd.Type) []xsd.Type {
 		for _, attr := range c.Attributes {
 			shadowedAttributes[attr.Name] = struct{}{}
 		}
-		
-		var baseElements []xsd.Element
 		for _, el := range b.Elements {
 			if _, ok := shadowedElements[el.Name]; !ok {
-				baseElements = append(baseElements, el)
+				c.Elements = append(c.Elements, el)
 			} else {
 				cfg.debugf("complexType %s: extended element %s is overrided",
 					c.Name.Local, el.Name.Local)
 			}
 		}
-		// prepend base elements, to preserve sequence order
-		c.Elements = append(baseElements, c.Elements...)
-		
 		for _, attr := range b.Attributes {
 			if _, ok := shadowedAttributes[attr.Name]; !ok {
 				c.Attributes = append(c.Attributes, attr)
@@ -691,12 +686,6 @@ func (cfg *Config) genComplexType(t *xsd.ComplexType) ([]spec, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s element %s: %v", t.Name.Local, el.Name.Local, err)
 		}
-		
-		// Use pointer for optional structs
-		if !el.Plural && fmt.Sprintf("%s", base) != "string" && (el.Nillable || el.Optional) {
-			base = ast.NewIdent(fmt.Sprintf("*%s", base))
-		}
-
 		name := namegen.element(el.Name)
 		if el.Wildcard {
 			tag = `xml:",any"`


### PR DESCRIPTION
Reverting droyo/go-xml#93 until we can fix #101 