### PR TITLE
Fix xsdDateTime.MarshalText method for considering timezone offset when marshalling

### DIFF
--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -327,7 +327,7 @@ func ExampleUseFieldNames() {
 	// 	return _unmarshalTime(text, (*time.Time)(t), "2006-01-02")
 	// }
 	// func (t xsdDate) MarshalText() ([]byte, error) {
-	// 	return []byte((time.Time)(t).Format("2006-01-02")), nil
+	// 	return _marshalTime((time.Time)(t), "2006-01-02")
 	// }
 	// func (t xsdDate) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	// 	if (time.Time)(t).IsZero() {
@@ -353,6 +353,9 @@ func ExampleUseFieldNames() {
 	// 		*t, err = time.Parse(format+"Z07:00", s)
 	// 	}
 	// 	return err
+	// }
+	// func _marshalTime(t time.Time, format string) ([]byte, error) {
+	// 	return []byte(t.Format(format + "Z07:00")), nil
 	// }
 
 }


### PR DESCRIPTION
Fixes: #113

This PR fixes the method xsdDateTime.MarshalText by adding the
support for considering the timezone offset when marshalling. Previously
it dropped the offset.

Modified the example_test as well.

As an addition, I removed the dead code for `*Config`'s method `errorf`. 