### PR TITLE
Fix warnings/errors reported by static code analysers

### DIFF
--- a/wsdl/wsdl.go
+++ b/wsdl/wsdl.go
@@ -56,9 +56,9 @@ type Message struct {
 func (m *Message) String() string {
 	parts := make([]string, 0, len(m.Parts))
 	for _, p := range m.Parts {
-		parts = append(parts, fmt.Sprintf("%s", p.Type.Local))
+		parts = append(parts, p.Type.Local)
 	}
-	return fmt.Sprintf("%s", strings.Join(parts, ", "))
+	return strings.Join(parts, ", ")
 }
 
 // A Part describes the name and type of a parameter to pass

--- a/wsdlgen/cli.go
+++ b/wsdlgen/cli.go
@@ -39,7 +39,9 @@ func (cfg *Config) GenCLI(arguments ...string) error {
 	)
 	fs.Var(&replaceRules, "r", "replacement rule 'regex -> repl' (can be used multiple times)")
 	fs.Var(&ports, "port", "gen code for this port (can be used multiple times)")
-	fs.Parse(arguments)
+	if err = fs.Parse(arguments); err != nil {
+		return err
+	}
 	if fs.NArg() == 0 {
 		return errors.New("Usage: wsdlgen [-r rule] [-o file] [-port name] [-pkg pkg] file ...")
 	}

--- a/wsdlgen/config.go
+++ b/wsdlgen/config.go
@@ -1,8 +1,6 @@
 package wsdlgen
 
 import (
-	"encoding/xml"
-
 	"aqwari.net/xml/wsdl"
 	"aqwari.net/xml/xsdgen"
 )
@@ -37,10 +35,6 @@ func (cfg *Config) debugf(format string, args ...interface{}) {
 	if cfg.loglevel > 2 {
 		cfg.logf(format, args...)
 	}
-}
-
-func (cfg *Config) publicName(name xml.Name) string {
-	return cfg.xsdgen.NameOf(name)
 }
 
 // Option applies the provides Options to a Config, modifying the

--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -362,7 +362,7 @@ func flattenRef(schema []*xmltree.Element) error {
 		unpackGroups(doc)
 		if hasCycle(doc, nil) {
 			return fmt.Errorf("cycle detected after flattening references "+
-				"in schema %d:\n%s\n", ns, xmltree.MarshalIndent(doc, "", "  "))
+				"in schema %d:\n%s", ns, xmltree.MarshalIndent(doc, "", "  "))
 		}
 	}
 	return nil

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -300,7 +300,6 @@ func XMLName(t Type) xml.Name {
 		return xml.Name(t)
 	}
 	panic(fmt.Sprintf("xsd: unexpected xsd.Type %[1]T %[1]v passed to XMLName", t))
-	return xml.Name{}
 }
 
 // Base returns the base type that a Type is derived from.

--- a/xsdgen/cli.go
+++ b/xsdgen/cli.go
@@ -99,7 +99,9 @@ func (cfg *Config) GenCLI(arguments ...string) error {
 	fs.Var(&replaceRules, "r", "replacement rule 'regex -> repl' (can be used multiple times)")
 	fs.Var(&xmlns, "ns", "target namespace(s) to generate types for")
 
-	fs.Parse(arguments)
+	if err = fs.Parse(arguments); err != nil {
+		return err
+	}
 	if fs.NArg() == 0 {
 		return errors.New("Usage: xsdgen [-ns xmlns] [-r rule] [-o file] [-pkg pkg] file ...")
 	}

--- a/xsdgen/config.go
+++ b/xsdgen/config.go
@@ -46,11 +46,6 @@ type typeTransform func(xsd.Schema, xsd.Type) xsd.Type
 type propertyFilter func(interface{}) bool
 type specTransform func(spec) spec
 
-func (cfg *Config) errorf(format string, v ...interface{}) {
-	if cfg.logger != nil {
-		cfg.logger.Printf(format, v...)
-	}
-}
 func (cfg *Config) logf(format string, v ...interface{}) {
 	if cfg.logger != nil && cfg.loglevel > 0 {
 		cfg.logger.Printf(format, v...)

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -932,38 +932,6 @@ func (cfg *Config) addSpecMethods(s spec) (spec, error) {
 	return s, nil
 }
 
-// Generate a type declaration for the bult-in list values, along with
-// marshal/unmarshal methods
-func (cfg *Config) addTokenListMethods(s spec, t *xsd.SimpleType) (spec, error) {
-	cfg.debugf("generating Go source for token list %q", s.name)
-	marshal, err := gen.Func("MarshalText").
-		Receiver("x *"+s.name).
-		Returns("[]byte", "error").
-		Body(`
-			return []byte(strings.Join(x, " ")), nil
-		`).Decl()
-
-	if err != nil {
-		return spec{}, fmt.Errorf("MarshalText %s: %v", s.name, err)
-	}
-
-	unmarshal, err := gen.Func("UnmarshalText").
-		Receiver("x *" + s.name).
-		Args("text []byte").
-		Returns("error").
-		Body(`
-			*x = bytes.Fields(text)
-			return nil
-		`).Decl()
-
-	if err != nil {
-		return spec{}, fmt.Errorf("UnmarshalText %s: %v", s.name, err)
-	}
-
-	s.methods = append(s.methods, marshal, unmarshal)
-	return s, nil
-}
-
 // Generate a type declaration for a <list> type, along with marshal/unmarshal
 // methods.
 func (cfg *Config) genSimpleListSpec(t *xsd.SimpleType) ([]spec, error) {


### PR DESCRIPTION
Tools used: go vet, staticcheck, golangci-lint

Fixed some basic, small errors such as:
1. Remove unnecessary use of fmt.Sprintf when arg is already a string
2. Check errors
3. Remove dead code blocks
4. Remove unreachable code
5. Don't put punctuation or new after error messages (in packages)

Sample output from `golangci-lint`, `staticcheck`:
* `staticcheck`:
```
wsdl/wsdl.go:59:25: the argument is already a string, there's no need to use fmt.Sprintf (S1025)
wsdl/wsdl.go:61:9: the argument is already a string, there's no need to use fmt.Sprintf (S1025)
wsdlgen/cli.go:44:10: error strings should not be capitalized (ST1005)
wsdlgen/cli.go:44:10: error strings should not end with punctuation or a newline (ST1005)
wsdlgen/config.go:42:20: func (*Config).publicName is unused (U1000)
xmltree/xmltree.go:272:12: error strings should not be capitalized (ST1005)
xmltree/xmltree_test.go:284:3: the surrounding loop is unconditionally terminated (SA4004)
xsd/parse.go:285:11: error strings should not be capitalized (ST1005)
xsd/parse.go:364:11: error strings should not end with punctuation or a newline (ST1005)
xsdgen/cli.go:104:10: error strings should not be capitalized (ST1005)
xsdgen/cli.go:104:10: error strings should not end with punctuation or a newline (ST1005)
xsdgen/config.go:49:20: func (*Config).errorf is unused (U1000)
xsdgen/config.go:438:16: error strings should not be capitalized (ST1005)
xsdgen/config.go:493:8: const soapenc is unused (U1000)
xsdgen/xsdgen.go:300:11: error strings should not end with punctuation or a newline (ST1005)
xsdgen/xsdgen.go:937:20: func (*Config).addTokenListMethods is unused (U1000)
``` 
* `golangci-lint`:
```
wsdl/wsdl.go:18:2: `mimeNS` is unused (deadcode)
	mimeNS    = "http://schemas.xmlsoap.org/wsdl/mime/"
	^
wsdl/wsdl.go:19:2: `soapencNS` is unused (deadcode)
	soapencNS = "http://schemas.xmlsoap.org/soap/encoding/"
	^
wsdl/wsdl.go:20:2: `soapenvNS` is unused (deadcode)
	soapenvNS = "http://schemas.xmlsoap.org/soap/envelope/"
	^
wsdl/wsdl.go:21:2: `xsiNS` is unused (deadcode)
	xsiNS     = "http://www.w3.org/2000/10/XMLSchema-instance"
	^
wsdl/wsdl.go:22:2: `xsdNS` is unused (deadcode)
	xsdNS     = "http://www.w3.org/2000/10/XMLSchema"
	^
xsd/xsd.go:29:2: `schemaInstanceNS` is unused (deadcode)
	schemaInstanceNS = "http://www.w3.org/2001/XMLSchema-instance"
	^
xmltree/marshal.go:90:12: Error return value of `e.w.Write` is not checked (errcheck)
		e.w.Write([]byte("<!-- cycle detected -->"))
		         ^
xmltree/marshal.go:99:13: Error return value of `e.w.Write` is not checked (errcheck)
			e.w.Write(el.Content)
			         ^
xmltree/marshal.go:139:18: Error return value of `io.WriteString` is not checked (errcheck)
			io.WriteString(e.w, e.indent)
			              ^
xmltree/marshal.go:151:18: Error return value of `io.WriteString` is not checked (errcheck)
			io.WriteString(e.w, "\n")
			              ^
xmltree/marshal.go:161:19: Error return value of `io.WriteString` is not checked (errcheck)
				io.WriteString(e.w, e.indent)
				              ^
xmltree/xmltree.go:330:10: Error return value of `el.walk` is not checked (errcheck)
		el.walk(search)
		       ^
xmltree/xmltree.go:332:11: Error return value of `root.walk` is not checked (errcheck)
	root.walk(search)
	         ^
xmltree/xmltree_test.go:164:9: Error return value of `el.walk` is not checked (errcheck)
	el.walk(func(el *Element) {
	       ^
xmltree/xmltree_test.go:165:10: Error return value of `el.walk` is not checked (errcheck)
		el.walk(func(el *Element) {
		       ^
xsdgen/cli.go:102:10: Error return value of `fs.Parse` is not checked (errcheck)
	fs.Parse(arguments)
	        ^
wsdlgen/cli.go:42:10: Error return value of `fs.Parse` is not checked (errcheck)
	fs.Parse(arguments)
	        ^
wsdlgen/wsdlgen.go:309:16: composites: `encoding/xml.Name` composite literal uses unkeyed fields (govet)
			XMLName:    xml.Name{p.wsdl.TargetNS, part.Name},
			            ^
wsdlgen/wsdlgen.go:331:13: composites: `encoding/xml.Name` composite literal uses unkeyed fields (govet)
			XMLName: xml.Name{p.wsdl.TargetNS, part.Name},
			         ^
xmltree/xmltree.go:134:9: composites: `encoding/xml.Name` composite literal uses unkeyed fields (govet)
	return xml.Name{defaultns, qname}
	       ^
xmltree/example_test.go:228:1: tests: ExampleMarshalNested refers to unknown identifier: MarshalNested (govet)
func ExampleMarshalNested() {
^
xsd/xsd.go:303:2: unreachable: unreachable code (govet)
	return xml.Name{}
	^
xmltree/xmltree_test.go:284:3: SA4004: the surrounding loop is unconditionally terminated (staticcheck)
		break
		^
xsdgen/config.go:488:8: const `soapenc` is unused (unused)
```