### PR TITLE
add parse documentation for each enumeration value

### DIFF
--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -850,6 +850,7 @@ func parseAnnotation(el *xmltree.Element) (doc annotation) {
 func parseSimpleRestriction(root *xmltree.Element, base Type) Restriction {
 	var r Restriction
 	var doc annotation
+	var enumDoc []annotation
 	// Most of the restrictions on a simpleType are suited for
 	// validating input. This package is not a validator; we assume
 	// that the server sends valid data, and that it will tell us if
@@ -859,6 +860,9 @@ func parseSimpleRestriction(root *xmltree.Element, base Type) Restriction {
 		switch el.Name.Local {
 		case "enumeration":
 			r.Enum = append(r.Enum, el.Attr("", "value"))
+			walk(el, func(enumChild *xmltree.Element) {
+				enumDoc = append(enumDoc, parseAnnotation(enumChild))
+			})
 		case "minExclusive", "minInclusive":
 			if v, ok := base.(Builtin); ok && v == Date {
 				d, err := time.Parse("2006-01-02", el.Attr("", "value"))
@@ -930,6 +934,10 @@ func parseSimpleRestriction(root *xmltree.Element, base Type) Restriction {
 		}
 	})
 	r.Doc = string(doc)
+	r.EnumDoc = make([]string, len(enumDoc))
+	for idx := range enumDoc {
+		r.EnumDoc[idx] = string(enumDoc[idx])
+	}
 	return r
 }
 

--- a/xsd/testdata/EnumWithDoc.json
+++ b/xsd/testdata/EnumWithDoc.json
@@ -1,0 +1,9 @@
+{
+  "RestrictionEnum": {
+    "Base": 38,
+    "Restriction": {
+      "Enum": ["FIRST", "SECOND"],
+      "EnumDoc": ["Documentation to value FIRST", "Documentation to value SECOND"]
+    }
+  }
+}

--- a/xsd/testdata/EnumWithDoc.json
+++ b/xsd/testdata/EnumWithDoc.json
@@ -2,8 +2,9 @@
   "RestrictionEnum": {
     "Base": 38,
     "Restriction": {
-      "Enum": ["FIRST", "SECOND"],
+      "Enum": ["FIRST", "SECOND", "OTHER"],
       "EnumDoc": ["Documentation to value FIRST", "Documentation to value SECOND"]
-    }
+    },
+    "Doc": "Documentation to restriction"
   }
 }

--- a/xsd/testdata/EnumWithDoc.xsd
+++ b/xsd/testdata/EnumWithDoc.xsd
@@ -1,0 +1,14 @@
+<simpleType name="RestrictionEnum">
+  <restriction base="string">
+    <enumeration value="FIRST">
+      <annotation>
+        <documentation>Documentation to value FIRST</documentation>
+      </annotation>
+    </enumeration>
+    <enumeration value="SECOND">
+      <annotation>
+        <documentation>Documentation to value SECOND</documentation>
+      </annotation>
+    </enumeration>
+  </restriction>
+</simpleType>

--- a/xsd/testdata/EnumWithDoc.xsd
+++ b/xsd/testdata/EnumWithDoc.xsd
@@ -1,4 +1,7 @@
 <simpleType name="RestrictionEnum">
+  <annotation>
+    <documentation>Documentation to restriction</documentation>
+  </annotation>
   <restriction base="string">
     <enumeration value="FIRST">
       <annotation>
@@ -10,5 +13,6 @@
         <documentation>Documentation to value SECOND</documentation>
       </annotation>
     </enumeration>
+    <enumeration value="OTHER"/>
   </restriction>
 </simpleType>

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -225,6 +225,8 @@ type Restriction struct {
 	// If len(Enum) > 0, the type must be one of the values contained
 	// in Enum.
 	Enum []string
+	// Any annotations for each Enum
+	EnumDoc []string
 	// The minimum and maximum (exclusive) value of this type, if
 	// numeric
 	Min, Max float64


### PR DESCRIPTION
Add parse documentation when annotation tag is inner tag enumeration.

Example:
```xml
<restriction base="string">
    <enumeration value="FIRST">
      <annotation>
        <documentation>Documentation to value FIRST</documentation>
      </annotation>
    </enumeration>
</restriction>
```