### PR TITLE
Fix error parsing AnySimpleType

### DIFF
--- a/xsd/builtin.go
+++ b/xsd/builtin.go
@@ -93,7 +93,7 @@ func (b Builtin) Name() xml.Name {
 // does not name a built-in type, ParseBuiltin returns
 // a non-nil error.
 func ParseBuiltin(qname xml.Name) (Builtin, error) {
-	for i := AnyType; i <= UnsignedShort; i++ {
+	for i := AnyType; i <= AnySimpleType; i++ {
 		if i.Name() == qname {
 			return i, nil
 		}


### PR DESCRIPTION
commit d7de88e1dfd94ebd3b0562f49285b7809286a360 introduce anySimpleType
but did not update the code which parsed builtins to consider it.

see #117 