### PR TITLE
optionally follow imports in xsd files

### DIFF
--- a/xsdgen/config.go
+++ b/xsdgen/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	loglevel        int
 	namespaces      []string
 	pkgname         string
+	// load xsd imports recursively into memory before parsing
+	followImports   bool
 	preprocessType  typeTransform
 	postprocessType specTransform
 	// Helper functions
@@ -231,6 +233,17 @@ func PackageName(name string) Option {
 		prev := cfg.pkgname
 		cfg.pkgname = name
 		return PackageName(prev)
+	}
+}
+
+// FollowImports specifies whether or not
+// to recursively read in imported schemas
+// before attempting to parse
+func FollowImports(follow bool) Option {
+	return func(cfg *Config) Option {
+		prev := cfg.followImports
+		cfg.followImports = follow
+		return FollowImports(prev)
 	}
 }
 


### PR DESCRIPTION
this reorganizes the logic around reading files such
that reading xsd files can recursively follow import
directives, automatically adding imported files into
the list of xsd files being parsed.

this removes the need to manually discovery
which combination of xsd files might be needed
in order to have a complete/parsable schema