### PR TITLE
teach xsd.Schema how to merge type maps

### DIFF
--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -147,7 +147,14 @@ func Parse(docs ...[]byte) ([]Schema, error) {
 		if err := s.parse(root); err != nil {
 			return nil, err
 		}
-		parsed[tns] = s
+		if existingSchema, found := parsed[tns]; found {
+			err = existingSchema.MergeTypes(&s)
+			if err != nil {
+				return nil, fmt.Errorf("error merging types into existing schema: %v", err)
+			}
+		} else {
+			parsed[tns] = s
+		}
 	}
 
 	for _, s := range parsed {

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"regexp"
+	"strings"
 	"time"
 
 	"aqwari.net/xml/xmltree"
@@ -108,6 +109,19 @@ type Schema struct {
 	// Any annotations declared at the top-level of the schema, separated
 	// by new lines.
 	Doc string
+}
+
+// MergeTypes adds the types from the incoming schema into
+// the receiving schema, returns error if the schemas have
+// different target namespaces.
+func (s *Schema) MergeTypes(incoming *Schema) error {
+	if !strings.EqualFold(s.TargetNS, incoming.TargetNS) {
+		return fmt.Errorf("cannot merge types from %s into %s", incoming.TargetNS, s.TargetNS)
+	}
+	for n,t := range incoming.Types {
+		s.Types[n] = t
+	}
+	return nil
 }
 
 // FindType looks for a type by its canonical name. In addition to the types


### PR DESCRIPTION
a new MergeTypes method is added to the xsd.Schema type
which merges the types from one xsd.Schema into another
provided that the TargetNS values are equivalent.

this MergeTypes method is then used when collecting
the map of namespaces to schemas so that when a single
schema is spread across multiple files (e.g. when
imports are used to tie them together) the types from
a namespace are all collected together, regardless of
which files they came from.

this allows the resolvePartialTypes method to operate
as expected, since following the imports will now
merge the types into a single xsd.Schema.