### PR TITLE
feat: use pointer for optional structures

### DIFF
--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -689,6 +689,15 @@ func (cfg *Config) genComplexType(t *xsd.ComplexType) ([]spec, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s element %s: %v", t.Name.Local, el.Name.Local, err)
 		}
+
+		_, isArrayType := base.(*ast.ArrayType)
+		if !el.Plural &&
+			fmt.Sprintf("%s", base) != "string" &&
+			!isArrayType &&
+			(el.Nillable || el.Optional) {
+			base = &ast.StarExpr{X: base}
+		}
+
 		name := namegen.element(el.Name)
 		if el.Wildcard {
 			tag = `xml:",any"`


### PR DESCRIPTION
Following the revert https://github.com/droyo/go-xml/pull/102 and your comment on https://github.com/droyo/go-xml/issues/101, I applied it and it seems to work well. I found the original xsd that was causing issue in #101  (https://www.fpml.org/spec/fpml-5-9-3-wd-3/html/recordkeeping/schemaDocumentation/schemas/xmldsig-core-schema_xsd/schema-overview.html#a76), but there was still issues with ArrayType nodes. Not using pointers for ArrayType fixed these.

Not sure if using pointers for optional fields is still of interest though.

Thanks for your work !