### PR TITLE
Better handling of imported xsds and namespace tag generation

### DIFF
--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -404,7 +404,7 @@ func deref(ref, real *xmltree.Element) *xmltree.Element {
 	el := new(xmltree.Element)
 	el.Scope = ref.Scope
 	el.Name = real.Name
-	el.StartElement.Attr = append([]xml.Attr{}, real.StartElement.Attr...)
+	el.StartElement.Attr = []xml.Attr{}
 	el.Content = append([]byte{}, real.Content...)
 	el.Children = append([]xmltree.Element{}, real.Children...)
 
@@ -413,11 +413,17 @@ func deref(ref, real *xmltree.Element) *xmltree.Element {
 	hasQName := map[xml.Name]bool{
 		xml.Name{"", "type"}: true,
 	}
-	for i, attr := range el.StartElement.Attr {
+	// Some attribute should not be copied
+	dontCopy := map[xml.Name]bool{
+		xml.Name{"", "name"}: true,
+		xml.Name{"", "form"}: true,
+	}
+	for _, attr := range real.StartElement.Attr {
 		if hasQName[attr.Name] {
 			xmlname := real.Resolve(attr.Value)
-			attr.Value = ref.Prefix(xmlname)
-			el.StartElement.Attr[i] = attr
+			el.SetAttr(attr.Name.Space, attr.Name.Local, ref.Prefix(xmlname))
+		} else if !dontCopy[attr.Name] {
+			el.SetAttr(attr.Name.Space, attr.Name.Local, attr.Value)
 		}
 	}
 	// If there are child elements, rather than checking all children
@@ -429,10 +435,15 @@ func deref(ref, real *xmltree.Element) *xmltree.Element {
 	// Attributes added to the reference overwrite attributes in the
 	// referenced element.
 	for _, attr := range ref.StartElement.Attr {
-		if (attr.Name != xml.Name{"", "ref"}) {
+		if (attr.Name == xml.Name{"", "ref"}) {
+			el.SetAttr("", "name", attr.Value)
+		} else {
 			el.SetAttr(attr.Name.Space, attr.Name.Local, attr.Value)
 		}
 	}
+
+	// Referenced elements are always qualified
+	el.SetAttr("", "form", "qualified")
 
 	return el
 }
@@ -840,10 +851,6 @@ func parseElement(ns string, el *xmltree.Element) Element {
 			doc = doc.append(parseAnnotation(el))
 		}
 	})
-	t, ok := e.Type.(linkedType)
-	if ok {
-		e.Name.Space = t.Space
-	}
 	e.Doc = string(doc)
 	e.Attr = el.StartElement.Attr
 	return e
@@ -857,8 +864,8 @@ func parseAttribute(ns string, el *xmltree.Element) Attribute {
 		a.Name = el.Resolve(el.Attr("", "name"))
 	} else {
 		a.Name.Local = name
+		a.Name.Space = ns
 	}
-	a.Name.Space = ns
 	a.Type = parseType(el.Resolve(el.Attr("", "type")))
 	a.Default = el.Attr("", "default")
 	a.Scope = el.Scope

--- a/xsd/parse.go
+++ b/xsd/parse.go
@@ -582,9 +582,10 @@ func attributeDefaultType(root *xmltree.Element) {
 	var (
 		isAttr    = isElem(schemaNS, "attribute")
 		hasNoType = hasAttrValue("", "type", "")
+		hasNoRef  = hasAttrValue("", "ref", "")
 		anyType   = xml.Name{Space: schemaNS, Local: "anySimpleType"}
 	)
-	for _, el := range root.SearchFunc(and(isAttr, hasNoType)) {
+	for _, el := range root.SearchFunc(and(isAttr, hasNoType, hasNoRef)) {
 		el.SetAttr("", "type", el.Prefix(anyType))
 	}
 }
@@ -598,9 +599,10 @@ func elementDefaultType(root *xmltree.Element) {
 	var (
 		isElement = isElem(schemaNS, "element")
 		hasNoType = hasAttrValue("", "type", "")
+		hasNoRef  = hasAttrValue("", "ref", "")
 		anyType   = xml.Name{Space: schemaNS, Local: "anyType"}
 	)
-	for _, el := range root.SearchFunc(and(isElement, hasNoType)) {
+	for _, el := range root.SearchFunc(and(isElement, hasNoType, hasNoRef)) {
 		el.SetAttr("", "type", el.Prefix(anyType))
 	}
 }

--- a/xsd/testdata/AttributeGroup.xsd
+++ b/xsd/testdata/AttributeGroup.xsd
@@ -9,7 +9,7 @@
 
 <complexType name="myElementType">
   <attributeGroup ref="tns:myAttributeGroup"/>
-  <element name="Field1" ref="tns:SomeElement" />
+  <element ref="tns:Field1" />
 </complexType>
 
-<element name="SomeElement" type="string" />
+<element name="Field1" type="string" />

--- a/xsd/testdata/ComplexType.json
+++ b/xsd/testdata/ComplexType.json
@@ -1,27 +1,27 @@
 {
   "CustomerType": {
     "Elements": [
-      {"Name": {"Local": "CompanyName"}, "Type": 38},
-      {"Name": {"Local": "ContactName"}, "Type": 38},
-      {"Name": {"Local": "ContactTitle"}, "Type": 38},
-      {"Name": {"Local": "Phone"}, "Type": 38},
-      {"Name": {"Local": "Fax"}, "Type": 38},
+      {"Name": {"Local": "CompanyName", "Space": "tns"}, "Type": 38},
+      {"Name": {"Local": "ContactName", "Space": "tns"}, "Type": 38},
+      {"Name": {"Local": "ContactTitle", "Space": "tns"}, "Type": 38},
+      {"Name": {"Local": "Phone", "Space": "tns"}, "Type": 38},
+      {"Name": {"Local": "Fax", "Space": "tns"}, "Type": 38},
       {
-        "Name": {"Local": "FullAddress"},
+        "Name": {"Local": "FullAddress", "Space": "tns"},
         "Type": {
           "Elements": [
-            {"Name": {"Local": "Address"}, "Type": 38},
-            {"Name": {"Local": "City"}, "Type": 38},
-            {"Name": {"Local": "Region"}, "Type": 38},
-            {"Name": {"Local": "PostalCode"}, "Type": 38},
-            {"Name": {"Local": "Country"}, "Type": 38}
+            {"Name": {"Local": "Address", "Space": "tns"}, "Type": 38},
+            {"Name": {"Local": "City", "Space": "tns"}, "Type": 38},
+            {"Name": {"Local": "Region", "Space": "tns"}, "Type": 38},
+            {"Name": {"Local": "PostalCode", "Space": "tns"}, "Type": 38},
+            {"Name": {"Local": "Country", "Space": "tns"}, "Type": 38}
           ],
-          "Attributes": [{"Name": {"Local": "CustomerID"}, "Type": 40}]
+          "Attributes": [{"Name": {"Local": "CustomerID", "Space": "tns"}, "Type": 40}]
         }
       }
     ],
     "Attributes": [
-      {"Name": {"Local": "CustomerID"}, "Type": 40}
+      {"Name": {"Local": "CustomerID", "Space": "tns"}, "Type": 40}
     ]
   }
 }

--- a/xsd/testdata/ComplexType.xsd
+++ b/xsd/testdata/ComplexType.xsd
@@ -5,13 +5,13 @@
     <element name='ContactTitle' type='string'/>
     <element name='Phone' type='string'/>
     <element name='Fax' minOccurs='0' type='string'/>
-    <element name='FullAddress' ref='tns:AddressType'/>
+    <element name='FullAddress' type='tns:AddressType'/>
   </sequence>
   <attribute name='CustomerID' type='token'/>
 </complexType>
 
-<element name='AddressType'>
-<complexType>
+
+<complexType name='AddressType'>
   <sequence>
     <element name='Address' type='string'/>
     <element name='City' type='string'/>
@@ -21,4 +21,3 @@
   </sequence>
   <attribute name='CustomerID' type='token'/>
 </complexType>
-</element>

--- a/xsd/xsd.go
+++ b/xsd/xsd.go
@@ -49,6 +49,8 @@ type Element struct {
 	Doc string
 	// The canonical name of this element
 	Name xml.Name
+	// What form of the naming to expect
+	Form FormOption
 	// True if this element can have any name. See
 	// http://www.w3.org/TR/2004/REC-xmlschema-1-20041028/structures.html#element-any
 	Wildcard bool
@@ -80,6 +82,8 @@ type Attribute struct {
 	// The canonical name of this attribute. It is uncommon for attributes
 	// to have a name space.
 	Name xml.Name
+	// What form of the naming to expect
+	Form FormOption
 	// Annotation provided for this attribute by the schema author.
 	Doc string
 	// The type of the attribute value. Must be a simple or built-in Type.
@@ -103,6 +107,10 @@ type Schema struct {
 	// The Target namespace of the schema. All types defined in this
 	// schema will be in this name space.
 	TargetNS string `xml:"targetNamespace,attr"`
+	// ElementFormDefault
+	ElementFormDefault FormOption `xml:"elementFormDefault,attr,omitempty"`
+	// AttributeFormDefault
+	AttributeFormDefault FormOption `xml:"attributeFormDefault,attr,omitempty"`
 	// Types defined in this schema declaration
 	Types map[xml.Name]Type
 	// Any annotations declared at the top-level of the schema, separated
@@ -329,3 +337,11 @@ var StandardSchema = [][]byte{
 	wsdl2003xsd,  // http://schemas.xmlsoap.org/wsdl/
 	xlinkxsd,     // http://www.w3.org/1999/xlink
 }
+
+type FormOption string
+
+const (
+	FormOptionUndefined   FormOption = ""
+	FormOptionUnqualified FormOption = "unqualified"
+	FormOptionQualified   FormOption = "qualified"
+)

--- a/xsd/xsd_test.go
+++ b/xsd/xsd_test.go
@@ -131,6 +131,7 @@ func testCompare(t *testing.T, prefix []string, got, want interface{}) bool {
 	}
 	if got != want {
 		t.Errorf("%s: got %#v, wanted %#v", path, got, want)
+		return false
 	}
 	return true
 }

--- a/xsdgen/cli.go
+++ b/xsdgen/cli.go
@@ -120,15 +120,16 @@ func (cfg *Config) GenSource(files ...string) ([]byte, error) {
 // same as those passed to the xsdgen command.
 func (cfg *Config) GenCLI(arguments ...string) error {
 	var (
-		err           error
-		replaceRules  commandline.ReplaceRuleList
-		xmlns         commandline.Strings
-		fs            = flag.NewFlagSet("xsdgen", flag.ExitOnError)
-		packageName   = fs.String("pkg", "", "name of the the generated package")
-		output        = fs.String("o", "xsdgen_output.go", "name of the output file")
-		followImports = fs.Bool("f", false, "follow import statements; load imported references recursively into scope")
-		verbose       = fs.Bool("v", false, "print verbose output")
-		debug         = fs.Bool("vv", false, "print debug output")
+		err                  error
+		replaceRules         commandline.ReplaceRuleList
+		xmlns                commandline.Strings
+		fs                   = flag.NewFlagSet("xsdgen", flag.ExitOnError)
+		packageName          = fs.String("pkg", "", "name of the the generated package")
+		output               = fs.String("o", "xsdgen_output.go", "name of the output file")
+		followImports        = fs.Bool("f", false, "follow import statements; load imported references recursively into scope")
+		targetNamespacesOnly = fs.Bool("t", false, "restict output of types to these declared in the target namespace(s) provided")
+		verbose              = fs.Bool("v", false, "print verbose output")
+		debug                = fs.Bool("vv", false, "print debug output")
 	)
 	fs.Var(&replaceRules, "r", "replacement rule 'regex -> repl' (can be used multiple times)")
 	fs.Var(&xmlns, "ns", "target namespace(s) to generate types for")
@@ -146,6 +147,7 @@ func (cfg *Config) GenCLI(arguments ...string) error {
 	}
 	cfg.Option(Namespaces(xmlns...))
 	cfg.Option(FollowImports(*followImports))
+	cfg.Option(TargetNamespacesOnly(*targetNamespacesOnly))
 	for _, r := range replaceRules {
 		cfg.Option(replaceAllNamesRegex(r.From, r.To))
 	}

--- a/xsdgen/config.go
+++ b/xsdgen/config.go
@@ -21,9 +21,10 @@ type Config struct {
 	namespaces      []string
 	pkgname         string
 	// load xsd imports recursively into memory before parsing
-	followImports   bool
-	preprocessType  typeTransform
-	postprocessType specTransform
+	followImports        bool
+	targetNamespacesOnly bool
+	preprocessType       typeTransform
+	postprocessType      specTransform
 	// Helper functions
 	helperFuncs map[string]*ast.FuncDecl
 	helperTypes map[xml.Name]spec
@@ -244,6 +245,18 @@ func FollowImports(follow bool) Option {
 		prev := cfg.followImports
 		cfg.followImports = follow
 		return FollowImports(prev)
+	}
+}
+
+// TargetNamespacesOnly specifies whether or
+// not to filter
+// to recursively read in imported schemas
+// before attempting to parse
+func TargetNamespacesOnly(tnsOnly bool) Option {
+	return func(cfg *Config) Option {
+		prev := cfg.targetNamespacesOnly
+		cfg.targetNamespacesOnly = tnsOnly
+		return TargetNamespacesOnly(prev)
 	}
 }
 

--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -109,8 +109,8 @@ func ExampleIgnoreElements() {
 	// package ws
 	//
 	// type Person struct {
-	// 	Name     string `xml:"http://www.example.com/ name"`
-	// 	Deceased bool   `xml:"http://schemas.xmlsoap.org/soap/encoding/ deceased"`
+	// 	Name     string `xml:"name"`
+	// 	Deceased bool   `xml:"deceased"`
 	// }
 }
 
@@ -190,7 +190,7 @@ func ExampleHandleSOAPArrayType() {
 	//
 	// type BoolArray struct {
 	// 	Items  []bool `xml:",any"`
-	// 	Offset string `xml:"offset,attr,omitempty"`
+	// 	Offset string `xml:"http://schemas.xmlsoap.org/soap/encoding/ offset,attr,omitempty"`
 	// 	Id     string `xml:"id,attr,omitempty"`
 	// 	Href   string `xml:"href,attr,omitempty"`
 	// }
@@ -291,16 +291,16 @@ func ExampleUseFieldNames() {
 	// )
 	//
 	// type Book struct {
-	// 	Title     string    `xml:"http://www.example.com/ title"`
-	// 	Published time.Time `xml:"http://www.example.com/ published"`
-	// 	Author    string    `xml:"http://www.example.com/ author"`
+	// 	Title     string    `xml:"title"`
+	// 	Published time.Time `xml:"published"`
+	// 	Author    string    `xml:"author"`
 	// }
 	//
 	//func (t *Book) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 	//	type T Book
 	//	var layout struct {
 	//		*T
-	//		Published *xsdDate `xml:"http://www.example.com/ published"`
+	//		Published *xsdDate `xml:"published"`
 	//	}
 	//	layout.T = (*T)(t)
 	//	layout.Published = (*xsdDate)(&layout.T.Published)
@@ -310,7 +310,7 @@ func ExampleUseFieldNames() {
 	//	type T Book
 	//	var overlay struct {
 	//		*T
-	//		Published *xsdDate `xml:"http://www.example.com/ published"`
+	//		Published *xsdDate `xml:"published"`
 	//	}
 	//	overlay.T = (*T)(t)
 	//	overlay.Published = (*xsdDate)(&overlay.T.Published)
@@ -318,7 +318,7 @@ func ExampleUseFieldNames() {
 	//}
 	//
 	// type Library struct {
-	// 	Book []Book `xml:"http://www.example.com/ book"`
+	// 	Book []Book `xml:"book"`
 	// }
 	//
 	// type xsdDate time.Time

--- a/xsdgen/example_test.go
+++ b/xsdgen/example_test.go
@@ -135,7 +135,7 @@ func ExamplePackageName() {
 	//
 	// package postal
 	//
-	// // May be no more than 10 items long
+	// // Must be exactly 10 items long
 	// type Zipcode string
 }
 
@@ -296,26 +296,26 @@ func ExampleUseFieldNames() {
 	// 	Author    string    `xml:"http://www.example.com/ author"`
 	// }
 	//
-	// func (t *Book) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
-	// 	type T Book
-	// 	var layout struct {
-	// 		*T
-	// 		Published *xsdDate `xml:"http://www.example.com/ published"`
-	// 	}
-	// 	layout.T = (*T)(t)
-	// 	layout.Published = (*xsdDate)(&layout.T.Published)
-	// 	return e.EncodeElement(layout, start)
-	// }
-	// func (t *Book) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
-	// 	type T Book
-	// 	var overlay struct {
-	// 		*T
-	// 		Published *xsdDate `xml:"http://www.example.com/ published"`
-	// 	}
-	// 	overlay.T = (*T)(t)
-	// 	overlay.Published = (*xsdDate)(&overlay.T.Published)
-	// 	return d.DecodeElement(&overlay, &start)
-	// }
+	//func (t *Book) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	//	type T Book
+	//	var layout struct {
+	//		*T
+	//		Published *xsdDate `xml:"http://www.example.com/ published"`
+	//	}
+	//	layout.T = (*T)(t)
+	//	layout.Published = (*xsdDate)(&layout.T.Published)
+	//	return e.EncodeElement(layout, start)
+	//}
+	//func (t *Book) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	//	type T Book
+	//	var overlay struct {
+	//		*T
+	//		Published *xsdDate `xml:"http://www.example.com/ published"`
+	//	}
+	//	overlay.T = (*T)(t)
+	//	overlay.Published = (*xsdDate)(&overlay.T.Published)
+	//	return d.DecodeElement(&overlay, &start)
+	//}
 	//
 	// type Library struct {
 	// 	Book []Book `xml:"http://www.example.com/ book"`

--- a/xsdgen/testdata/common.xsd
+++ b/xsdgen/testdata/common.xsd
@@ -1,0 +1,14 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="common" xmlns:cmn="common" version="0100">
+    <simpleType name="Simple">
+        <restriction base="string">
+            <minLength value="1"/>
+            <maxLength value="20"/>
+        </restriction>
+    </simpleType>
+    <complexType name="Complex">
+        <sequence>
+            <element name="Simple1" type="cmn:Simple"/>
+            <element name="Simple2" type="cmn:Simple"/>
+        </sequence>
+    </complexType>
+</schema>

--- a/xsdgen/testdata/ns1.xsd
+++ b/xsdgen/testdata/ns1.xsd
@@ -1,0 +1,12 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="ns1" xmlns:ns1="ns1" xmlns:ns2="ns2" xmlns:cmn="common" version="0100">
+    <import namespace="ns2" schemaLocation="ns2.xsd"/>
+    <import namespace="common" schemaLocation="common.xsd"/>
+    <element name="CombinedType">
+        <complexType>
+            <sequence>
+                <element name="Typed" type="cmn:Simple"/>
+                <element ref="ns2:ReferrableType"/>
+            </sequence>
+        </complexType>
+    </element>
+</schema>

--- a/xsdgen/testdata/ns2.xsd
+++ b/xsdgen/testdata/ns2.xsd
@@ -1,0 +1,10 @@
+<schema xmlns="http://www.w3.org/2001/XMLSchema" targetNamespace="ns2" xmlns:ns2="ns2" xmlns:cmn="common" version="0100">
+    <import namespace="common" schemaLocation="common.xsd"/>
+    <element name="ReferrableType">
+        <complexType>
+            <sequence>
+                <element name="Typed" type="cmn:Complex"/>
+            </sequence>
+        </complexType>
+    </element>
+</schema>

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -463,6 +463,10 @@ func (cfg *Config) flatten1(t xsd.Type, push func(xsd.Type), depth int) xsd.Type
 			t.Doc = "Must be at least " + strconv.Itoa(t.Restriction.MinLength) + " items long"
 			return t
 		}
+		if t.Restriction.Length != 0 {
+			t.Doc = "Must be exactly " + strconv.Itoa(t.Restriction.Length) + " items long"
+			return t
+		}
 		return t.Base
 	case *xsd.ComplexType:
 		// We can "unpack" a struct if it is extending a simple

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -528,7 +528,21 @@ func (cfg *Config) flatten1(t xsd.Type, push func(xsd.Type), depth int) xsd.Type
 
 func (cfg *Config) genTypeSpec(t xsd.Type) (result []spec, err error) {
 	var s []spec
-	cfg.debugf("generating type spec for %q", xsd.XMLName(t).Local)
+
+	name := xsd.XMLName(t)
+	if cfg.targetNamespacesOnly {
+		found := false
+		for _, ns := range cfg.namespaces {
+			if ns == name.Space {
+				found = true
+			}
+		}
+		if !found {
+			return result, nil
+		}
+	}
+
+	cfg.debugf("generating type spec for %q", name.Local)
 
 	switch t := t.(type) {
 	case *xsd.SimpleType:
@@ -538,7 +552,7 @@ func (cfg *Config) genTypeSpec(t xsd.Type) (result []spec, err error) {
 	case xsd.Builtin:
 		// pass
 	default:
-		cfg.logf("unexpected %T %s", t, xsd.XMLName(t).Local)
+		cfg.logf("unexpected %T %s", t, name.Local)
 	}
 	if err != nil || s == nil {
 		return result, err

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -689,15 +689,8 @@ func (cfg *Config) genComplexType(t *xsd.ComplexType) ([]spec, error) {
 			options = ",omitempty"
 		}
 
-		qualified := false
-		for _, attr := range el.Attr {
-			if attr.Name.Space == "" && attr.Name.Local == "form" && attr.Value == "qualified" {
-				qualified = true
-			}
-		}
-
 		tag := ""
-		if qualified || t.Name.Space != el.Name.Space {
+		if el.Form == xsd.FormOptionQualified || t.Name.Space != el.Name.Space {
 			tag = fmt.Sprintf(`xml:"%s %s%s"`, el.Name.Space, el.Name.Local, options)
 		} else {
 			tag = fmt.Sprintf(`xml:"%s%s"`, el.Name.Local, options)
@@ -749,14 +742,8 @@ func (cfg *Config) genComplexType(t *xsd.ComplexType) ([]spec, error) {
 		if attr.Optional {
 			options = ",omitempty"
 		}
-		qualified := false
-		for _, attrAttr := range attr.Attr {
-			if attrAttr.Name.Space == "" && attrAttr.Name.Local == "form" && attrAttr.Value == "qualified" {
-				qualified = true
-			}
-		}
 		var tag string
-		if qualified {
+		if attr.Form == xsd.FormOptionQualified {
 			tag = fmt.Sprintf(`xml:"%s %s,attr%s"`, attr.Name.Space, attr.Name.Local, options)
 		} else {
 			tag = fmt.Sprintf(`xml:"%s,attr%s"`, attr.Name.Local, options)

--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -688,7 +688,21 @@ func (cfg *Config) genComplexType(t *xsd.ComplexType) ([]spec, error) {
 		if el.Nillable || el.Optional {
 			options = ",omitempty"
 		}
-		tag := fmt.Sprintf(`xml:"%s %s%s"`, el.Name.Space, el.Name.Local, options)
+
+		qualified := false
+		for _, attr := range el.Attr {
+			if attr.Name.Space == "" && attr.Name.Local == "form" && attr.Value == "qualified" {
+				qualified = true
+			}
+		}
+
+		tag := ""
+		if qualified || t.Name.Space != el.Name.Space {
+			tag = fmt.Sprintf(`xml:"%s %s%s"`, el.Name.Space, el.Name.Local, options)
+		} else {
+			tag = fmt.Sprintf(`xml:"%s%s"`, el.Name.Local, options)
+		}
+
 		base, err := cfg.expr(el.Type)
 		if err != nil {
 			return nil, fmt.Errorf("%s element %s: %v", t.Name.Local, el.Name.Local, err)

--- a/xsdgen/xsdgen_test.go
+++ b/xsdgen/xsdgen_test.go
@@ -47,7 +47,7 @@ func testGen(t *testing.T, ns string, files ...string) string {
 	cfg.Option(DefaultOptions...)
 	cfg.Option(LogOutput((*testLogger)(t)))
 
-	args := []string{"-v", "-o", file.Name(), "-ns", ns}
+	args := []string{"-v", "-o", file.Name(), "-ns", ns, "-f"}
 	err = cfg.GenCLI(append(args, files...)...)
 	if err != nil {
 		t.Error(err)
@@ -74,4 +74,8 @@ func TestBase64Binary(t *testing.T) {
 
 func TestSimpleUnion(t *testing.T) {
 	t.Logf("%s\n", testGen(t, "http://example.org/", "testdata/simple-union.xsd"))
+}
+
+func TestImports(t *testing.T) {
+	t.Logf("%s\n", testGen(t, "ns1", "testdata/ns1.xsd"))
 }


### PR DESCRIPTION
These are my accumulated changes with regard to:
xsdgen: imports (being relative)
xsd: type handling (referencing elements should not get a default type)
xsd/xsdgen: generation of namespace information in golang struct xml tags only in case there is a need (reference / form="qualified" or different namespace)
xsdgen: generation of only these types that have been defined in the targetNamespace(s) provided