### PR TITLE
Use pointer type for nillable elements

### DIFF
--- a/xsdgen/xsdgen.go
+++ b/xsdgen/xsdgen.go
@@ -704,6 +704,8 @@ func (cfg *Config) genComplexType(t *xsd.ComplexType) ([]spec, error) {
 		}
 		if el.Plural {
 			base = &ast.ArrayType{Elt: base}
+		} else if el.Nillable {
+			base = &ast.StarExpr{X: base}
 		}
 		fields = append(fields, name, base, gen.String(tag))
 		if el.Default != "" || nonTrivialBuiltin(el.Type) {


### PR DESCRIPTION
Use pointer type for nillable elements as described in [xsd.Element.Nillable](https://github.com/droyo/go-xml/blob/d9421b29381771b31dcc35151bdc554d586f1e60/xsd/xsd.go#L64).

This allows in defining a recursive complexType, like so:

```
<xs:complexType name="composite">
  <xs:choice>
    <xs:element name="leaf" nillable="true" minOccurs="0">
      <xs:complexType/>
    </xs:element>
    <xs:element name="delegate" type="composite" nillable="true" minOccurs="0"/>
  </xs:choice>
</xs:complexType>
```

Otherwise the above results in generating (xml annotations removed for brevity):

```
type Leaf struct {}
type Composite struct {
  Leaf Leaf
  Delegate Composite
}
```

The above cannot compile. Composite struct contains itself which would result in infinite expansion of the struct.

Instead, when introducing a pointer of a nillable element:

```
type Leaf struct {}
type Composite struct {
  Leaf *Leaf
  Delegate *Composite
}
```

The above compiles.

The example using pointers also matches Go pattern of using nil to explicitly mark absence where only some of many values are expected (semantics of `xs:choice`).